### PR TITLE
Activation opts + Softmax

### DIFF
--- a/activation.go
+++ b/activation.go
@@ -1,0 +1,31 @@
+package gan_go
+
+import (
+	"gorgonia.org/gorgonia"
+)
+
+// ActivationFunc Just an alias to Gorgonia'a api_gen.go - https://github.com/gorgonia/gorgonia/blob/master/api_gen.go#L1
+type ActivationFunc func(a *gorgonia.Node) (*gorgonia.Node, error)
+
+func NoActivation(a *gorgonia.Node) (*gorgonia.Node, error) { return a, nil }
+func Abs(a *gorgonia.Node) (*gorgonia.Node, error)          { return gorgonia.Abs(a) }
+func Sign(a *gorgonia.Node) (*gorgonia.Node, error)         { return gorgonia.Sign(a) }
+func Ceil(a *gorgonia.Node) (*gorgonia.Node, error)         { return gorgonia.Ceil(a) }
+func Floor(a *gorgonia.Node) (*gorgonia.Node, error)        { return gorgonia.Floor(a) }
+func Sin(a *gorgonia.Node) (*gorgonia.Node, error)          { return gorgonia.Sin(a) }
+func Cos(a *gorgonia.Node) (*gorgonia.Node, error)          { return gorgonia.Cos(a) }
+func Exp(a *gorgonia.Node) (*gorgonia.Node, error)          { return gorgonia.Exp(a) }
+func Log(a *gorgonia.Node) (*gorgonia.Node, error)          { return gorgonia.Log(a) }
+func Log2(a *gorgonia.Node) (*gorgonia.Node, error)         { return gorgonia.Log2(a) }
+func Neg(a *gorgonia.Node) (*gorgonia.Node, error)          { return gorgonia.Neg(a) }
+func Square(a *gorgonia.Node) (*gorgonia.Node, error)       { return gorgonia.Square(a) }
+func Sqrt(a *gorgonia.Node) (*gorgonia.Node, error)         { return gorgonia.Sqrt(a) }
+func Inverse(a *gorgonia.Node) (*gorgonia.Node, error)      { return gorgonia.Inverse(a) }
+func InverseSqrt(a *gorgonia.Node) (*gorgonia.Node, error)  { return gorgonia.InverseSqrt(a) }
+func Cube(a *gorgonia.Node) (*gorgonia.Node, error)         { return gorgonia.Cube(a) }
+func Tanh(a *gorgonia.Node) (*gorgonia.Node, error)         { return gorgonia.Tanh(a) }
+func Sigmoid(a *gorgonia.Node) (*gorgonia.Node, error)      { return gorgonia.Sigmoid(a) }
+func Log1p(a *gorgonia.Node) (*gorgonia.Node, error)        { return gorgonia.Log1p(a) }
+func Expm1(a *gorgonia.Node) (*gorgonia.Node, error)        { return gorgonia.Expm1(a) }
+func Softplus(a *gorgonia.Node) (*gorgonia.Node, error)     { return gorgonia.Softplus(a) }
+func Rectify(a *gorgonia.Node) (*gorgonia.Node, error)      { return gorgonia.Rectify(a) }

--- a/activation.go
+++ b/activation.go
@@ -5,27 +5,44 @@ import (
 )
 
 // ActivationFunc Just an alias to Gorgonia'a api_gen.go - https://github.com/gorgonia/gorgonia/blob/master/api_gen.go#L1
-type ActivationFunc func(a *gorgonia.Node) (*gorgonia.Node, error)
+type ActivationFunc func(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error)
 
-func NoActivation(a *gorgonia.Node) (*gorgonia.Node, error) { return a, nil }
-func Abs(a *gorgonia.Node) (*gorgonia.Node, error)          { return gorgonia.Abs(a) }
-func Sign(a *gorgonia.Node) (*gorgonia.Node, error)         { return gorgonia.Sign(a) }
-func Ceil(a *gorgonia.Node) (*gorgonia.Node, error)         { return gorgonia.Ceil(a) }
-func Floor(a *gorgonia.Node) (*gorgonia.Node, error)        { return gorgonia.Floor(a) }
-func Sin(a *gorgonia.Node) (*gorgonia.Node, error)          { return gorgonia.Sin(a) }
-func Cos(a *gorgonia.Node) (*gorgonia.Node, error)          { return gorgonia.Cos(a) }
-func Exp(a *gorgonia.Node) (*gorgonia.Node, error)          { return gorgonia.Exp(a) }
-func Log(a *gorgonia.Node) (*gorgonia.Node, error)          { return gorgonia.Log(a) }
-func Log2(a *gorgonia.Node) (*gorgonia.Node, error)         { return gorgonia.Log2(a) }
-func Neg(a *gorgonia.Node) (*gorgonia.Node, error)          { return gorgonia.Neg(a) }
-func Square(a *gorgonia.Node) (*gorgonia.Node, error)       { return gorgonia.Square(a) }
-func Sqrt(a *gorgonia.Node) (*gorgonia.Node, error)         { return gorgonia.Sqrt(a) }
-func Inverse(a *gorgonia.Node) (*gorgonia.Node, error)      { return gorgonia.Inverse(a) }
-func InverseSqrt(a *gorgonia.Node) (*gorgonia.Node, error)  { return gorgonia.InverseSqrt(a) }
-func Cube(a *gorgonia.Node) (*gorgonia.Node, error)         { return gorgonia.Cube(a) }
-func Tanh(a *gorgonia.Node) (*gorgonia.Node, error)         { return gorgonia.Tanh(a) }
-func Sigmoid(a *gorgonia.Node) (*gorgonia.Node, error)      { return gorgonia.Sigmoid(a) }
-func Log1p(a *gorgonia.Node) (*gorgonia.Node, error)        { return gorgonia.Log1p(a) }
-func Expm1(a *gorgonia.Node) (*gorgonia.Node, error)        { return gorgonia.Expm1(a) }
-func Softplus(a *gorgonia.Node) (*gorgonia.Node, error)     { return gorgonia.Softplus(a) }
-func Rectify(a *gorgonia.Node) (*gorgonia.Node, error)      { return gorgonia.Rectify(a) }
+func NoActivation(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error) { return a, nil }
+func Abs(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error)          { return gorgonia.Abs(a) }
+func Sign(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error)         { return gorgonia.Sign(a) }
+func Ceil(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error)         { return gorgonia.Ceil(a) }
+func Floor(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error)        { return gorgonia.Floor(a) }
+func Sin(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error)          { return gorgonia.Sin(a) }
+func Cos(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error)          { return gorgonia.Cos(a) }
+func Exp(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error)          { return gorgonia.Exp(a) }
+func Log(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error)          { return gorgonia.Log(a) }
+func Log2(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error)         { return gorgonia.Log2(a) }
+func Neg(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error)          { return gorgonia.Neg(a) }
+func Square(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error)       { return gorgonia.Square(a) }
+func Sqrt(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error)         { return gorgonia.Sqrt(a) }
+func Inverse(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error)      { return gorgonia.Inverse(a) }
+func InverseSqrt(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error) {
+	return gorgonia.InverseSqrt(a)
+}
+func Cube(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error)     { return gorgonia.Cube(a) }
+func Tanh(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error)     { return gorgonia.Tanh(a) }
+func Sigmoid(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error)  { return gorgonia.Sigmoid(a) }
+func Log1p(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error)    { return gorgonia.Log1p(a) }
+func Expm1(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error)    { return gorgonia.Expm1(a) }
+func Softplus(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error) { return gorgonia.Softplus(a) }
+func Rectify(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error)  { return gorgonia.Rectify(a) }
+func Softmax(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error) {
+	for i := range opts {
+		// Check if axis option is provided
+		// First i-th option with provided field 'Axis' would be considered for use.
+		if len(opts[i].Axis) > 0 {
+			return gorgonia.SoftMax(a, opts[i].Axis...)
+		}
+	}
+	return gorgonia.SoftMax(a)
+}
+
+// Options Struct for holding options for certain activation functions.
+type Options struct {
+	Axis []int
+}

--- a/activation.go
+++ b/activation.go
@@ -46,3 +46,12 @@ func Softmax(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error) {
 type Options struct {
 	Axis []int
 }
+
+// WithActivationOptions Wrap function with custom options
+func WithActivationOptions(f ActivationFunc, opts ...Options) ActivationFunc {
+	newF := func(a *gorgonia.Node, opts_ignored ...Options) (*gorgonia.Node, error) {
+		// Apply parent-scoped options to function call
+		return f(a, opts...)
+	}
+	return newF
+}

--- a/layer.go
+++ b/layer.go
@@ -19,32 +19,6 @@ type Layer struct {
 	ReshapeDims  []int
 }
 
-// ActivationFunc Just an alias to Gorgonia'a api_gen.go - https://github.com/gorgonia/gorgonia/blob/master/api_gen.go#L1
-type ActivationFunc func(a *gorgonia.Node) (*gorgonia.Node, error)
-
-func NoActivation(a *gorgonia.Node) (*gorgonia.Node, error) { return a, nil }
-func Abs(a *gorgonia.Node) (*gorgonia.Node, error)          { return gorgonia.Abs(a) }
-func Sign(a *gorgonia.Node) (*gorgonia.Node, error)         { return gorgonia.Sign(a) }
-func Ceil(a *gorgonia.Node) (*gorgonia.Node, error)         { return gorgonia.Ceil(a) }
-func Floor(a *gorgonia.Node) (*gorgonia.Node, error)        { return gorgonia.Floor(a) }
-func Sin(a *gorgonia.Node) (*gorgonia.Node, error)          { return gorgonia.Sin(a) }
-func Cos(a *gorgonia.Node) (*gorgonia.Node, error)          { return gorgonia.Cos(a) }
-func Exp(a *gorgonia.Node) (*gorgonia.Node, error)          { return gorgonia.Exp(a) }
-func Log(a *gorgonia.Node) (*gorgonia.Node, error)          { return gorgonia.Log(a) }
-func Log2(a *gorgonia.Node) (*gorgonia.Node, error)         { return gorgonia.Log2(a) }
-func Neg(a *gorgonia.Node) (*gorgonia.Node, error)          { return gorgonia.Neg(a) }
-func Square(a *gorgonia.Node) (*gorgonia.Node, error)       { return gorgonia.Square(a) }
-func Sqrt(a *gorgonia.Node) (*gorgonia.Node, error)         { return gorgonia.Sqrt(a) }
-func Inverse(a *gorgonia.Node) (*gorgonia.Node, error)      { return gorgonia.Inverse(a) }
-func InverseSqrt(a *gorgonia.Node) (*gorgonia.Node, error)  { return gorgonia.InverseSqrt(a) }
-func Cube(a *gorgonia.Node) (*gorgonia.Node, error)         { return gorgonia.Cube(a) }
-func Tanh(a *gorgonia.Node) (*gorgonia.Node, error)         { return gorgonia.Tanh(a) }
-func Sigmoid(a *gorgonia.Node) (*gorgonia.Node, error)      { return gorgonia.Sigmoid(a) }
-func Log1p(a *gorgonia.Node) (*gorgonia.Node, error)        { return gorgonia.Log1p(a) }
-func Expm1(a *gorgonia.Node) (*gorgonia.Node, error)        { return gorgonia.Expm1(a) }
-func Softplus(a *gorgonia.Node) (*gorgonia.Node, error)     { return gorgonia.Softplus(a) }
-func Rectify(a *gorgonia.Node) (*gorgonia.Node, error)      { return gorgonia.Rectify(a) }
-
 type LayerType uint16
 
 const (


### PR DESCRIPTION
1. Added Softmax function from Gorgonia - https://github.com/gorgonia/gorgonia/blob/d77dcd9135e961ba5f477e209aa057b3cf437a58/operations.go#L182
2. Now every activation function accepts both *gorgonia.Node* and variadic *Option* struct (read further)
1. Added *Option* struct.
```go
// Options Struct for holding options for certain activation functions.
type Options struct {
	Axis []int
}
```
Current fields: Axis.
Possible usage: Due the introducing of Softmax function, it's needed to add *axis=0,1,...,N* option for some reasons.
4. Added WithActivationOptions 
```go
// WithActivationOptions Wrap function with custom options
func WithActivationOptions(f ActivationFunc, opts ...Options) ActivationFunc {
	newF := func(a *gorgonia.Node, opts_ignored ...Options) (*gorgonia.Node, error) {
		// Apply parent-scoped options to function call
		return f(a, opts...)
	}
	return newF
}
```
Possible usage:
```go
// While building single layer of []*gan.Layer slice:
{
    WeightNode: /* some weights node */,
    BiasNode:   /* some bias node */,
    Type:       gan.LayerLinear,

    // Use softmax for user defined axis
    Activation: gan.WithActivationOptions(gan.Softmax, gan.Options{Axis: []int{1, 2}}),
}
```