### PR TITLE
[BREAKING] Refactor Layer from struct to interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Plotting library - [gonum](https://github.com/gonum/plot#gonum-plot)
 ## ToDo
 Current stage of TODO list for future releases:
 - [x] Reduce duplicating of code for *.Fwd()* method of each neural network type (GAN/Discriminator/Generator)
-- [ ] Switch **Layer** from *struct* to *interface* or use other technique for building clean code
+- [x] Switch **Layer** from *struct* to *interface* or use other technique for building clean code
 - [x] Add basic layers: Linear, Convolutional, Maxpool, Flatten
 - [ ] Deal with batch process 
 - [x] More loss function

--- a/activation.go
+++ b/activation.go
@@ -4,6 +4,11 @@ import (
 	"gorgonia.org/gorgonia"
 )
 
+// Options Struct for holding parameters for certain activation functions (e.g. axis for Softmax)
+type Options struct {
+	Axis []int
+}
+
 // ActivationFunc Just an alias to Gorgonia'a api_gen.go - https://github.com/gorgonia/gorgonia/blob/master/api_gen.go#L1
 type ActivationFunc func(a *gorgonia.Node, opts ...Options) (*gorgonia.Node, error)
 

--- a/cmd/examples/generate_smiley_face/main.go
+++ b/cmd/examples/generate_smiley_face/main.go
@@ -357,41 +357,26 @@ func defineDiscriminator(g *gorgonia.ExprGraph) *gan.DiscriminatorNet {
 	dis_shp1 := tensor.Shape{1, 12 * 4 * 3}
 	dis_w1 := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(dis_shp1...), gorgonia.WithName("discriminator_train_w1"), gorgonia.WithInit(gorgonia.GlorotN(1.0)))
 	discriminator := gan.Discriminator(
-		[]*gan.Layer{
-			{
-				WeightNode: dis_w0,
-				BiasNode:   nil,
-				Type:       gan.LayerConvolutional,
-				Activation: gan.Rectify,
-				Options: &gan.Options{
-					KernelHeight: 3,
-					KernelWidth:  3,
-					Padding:      []int{0, 0},
-					Stride:       []int{1, 1},
-					Dilation:     []int{1, 1},
-				},
-			},
-			{
-				Type:       gan.LayerMaxpool,
-				Activation: gan.NoActivation,
-				Options: &gan.Options{
-					KernelHeight: 2,
-					KernelWidth:  2,
-					Padding:      []int{0, 0},
-					Stride:       []int{2, 2},
-				},
-			},
-			{
-				Type:       gan.LayerFlatten,
-				Activation: gan.NoActivation,
-			},
-			{
-				WeightNode: dis_w1,
-				BiasNode:   nil,
-				Type:       gan.LayerLinear,
-				Activation: gan.Sigmoid,
-			},
-		}...,
+		&gan.Conv2DLayer{
+			WeightNode:   dis_w0,
+			Activation:   gan.Rectify,
+			KernelHeight: 3,
+			KernelWidth:  3,
+			Padding:      []int{0, 0},
+			Stride:       []int{1, 1},
+			Dilation:     []int{1, 1},
+		},
+		&gan.MaxpoolLayer{
+			KernelHeight: 2,
+			KernelWidth:  2,
+			Padding:      []int{0, 0},
+			Stride:       []int{2, 2},
+		},
+		&gan.FlattenLayer{},
+		&gan.LinearLayer{
+			WeightNode: dis_w1,
+			Activation: gan.Sigmoid,
+		},
 	)
 	return discriminator
 }
@@ -425,147 +410,90 @@ func defineGenerator(g *gorgonia.ExprGraph) *gan.GeneratorNet {
 	gen_w5 := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(gen_shp5...), gorgonia.WithName("generator_w6"), gorgonia.WithInit(gorgonia.GlorotN(1.0)))
 
 	generator := gan.Generator(
-		[]*gan.Layer{
-			{
-				WeightNode: gen_w0,
-				BiasNode:   nil,
-				Type:       gan.LayerConvolutional,
-				Activation: gan.Rectify,
-				Options: &gan.Options{
-					KernelHeight: 3,
-					KernelWidth:  3,
-					Padding:      []int{0, 0},
-					Stride:       []int{1, 1},
-					Dilation:     []int{1, 1},
-				},
-			},
-			{
-				Type: gan.LayerDropout,
-				Options: &gan.Options{
-					Probability: 0.6,
-				},
-			},
-			{
-				Type:       gan.LayerMaxpool,
-				Activation: gan.NoActivation,
-				Options: &gan.Options{
-					KernelHeight: 2,
-					KernelWidth:  2,
-					Padding:      []int{0, 0},
-					Stride:       []int{2, 2},
-				},
-			},
-			{
-				WeightNode: gen_w1,
-				BiasNode:   nil,
-				Type:       gan.LayerConvolutional,
-				Activation: gan.Rectify,
-				Options: &gan.Options{
-					KernelHeight: 3,
-					KernelWidth:  3,
-					Padding:      []int{0, 0},
-					Stride:       []int{1, 1},
-					Dilation:     []int{1, 1},
-				},
-			},
-			{
-				Type: gan.LayerDropout,
-				Options: &gan.Options{
-					Probability: 0.5,
-				},
-			},
-			{
-				Type:       gan.LayerMaxpool,
-				Activation: gan.NoActivation,
-				Options: &gan.Options{
-					KernelHeight: 2,
-					KernelWidth:  2,
-					Padding:      []int{0, 0},
-					Stride:       []int{2, 2},
-				},
-			},
-			{
-				WeightNode: gen_w2,
-				BiasNode:   nil,
-				Type:       gan.LayerConvolutional,
-				Activation: gan.Rectify,
-				Options: &gan.Options{
-					KernelHeight: 3,
-					KernelWidth:  3,
-					Padding:      []int{0, 0},
-					Stride:       []int{1, 1},
-					Dilation:     []int{1, 1},
-				},
-			},
-			{
-				Type: gan.LayerDropout,
-				Options: &gan.Options{
-					Probability: 0.2,
-				},
-			},
-			{
-				Type:       gan.LayerMaxpool,
-				Activation: gan.NoActivation,
-				Options: &gan.Options{
-					KernelHeight: 2,
-					KernelWidth:  2,
-					Padding:      []int{0, 0},
-					Stride:       []int{2, 2},
-				},
-			},
-			{
-				WeightNode: gen_w3,
-				BiasNode:   nil,
-				Type:       gan.LayerConvolutional,
-				Activation: gan.Rectify,
-				Options: &gan.Options{
-					KernelHeight: 3,
-					KernelWidth:  3,
-					Padding:      []int{0, 0},
-					Stride:       []int{1, 1},
-					Dilation:     []int{1, 1},
-				},
-			},
-			{
-				Type: gan.LayerDropout,
-				Options: &gan.Options{
-					Probability: 0.2,
-				},
-			},
-			{
-				Type:       gan.LayerMaxpool,
-				Activation: gan.NoActivation,
-				Options: &gan.Options{
-					KernelHeight: 2,
-					KernelWidth:  2,
-					Padding:      []int{0, 0},
-					Stride:       []int{2, 2},
-				},
-			},
-			{
-				Type:       gan.LayerFlatten,
-				Activation: gan.NoActivation,
-			},
-			{
-				WeightNode: gen_w4,
-				BiasNode:   nil,
-				Type:       gan.LayerLinear,
-				Activation: gan.Sigmoid,
-			},
-			{
-				WeightNode: gen_w5,
-				BiasNode:   nil,
-				Type:       gan.LayerLinear,
-				Activation: gan.Sigmoid,
-			},
-			{
-				Type:       gan.LayerReshape,
-				Activation: gan.NoActivation,
-				Options: &gan.Options{
-					ReshapeDims: []int{1, 1, imgHeight, imgWidth},
-				},
-			},
-		}...,
+		&gan.Conv2DLayer{
+			WeightNode:   gen_w0,
+			Activation:   gan.Rectify,
+			KernelHeight: 3,
+			KernelWidth:  3,
+			Padding:      []int{0, 0},
+			Stride:       []int{1, 1},
+			Dilation:     []int{1, 1},
+		},
+		&gan.DropoutLayer{
+			Probability: 0.6,
+		},
+		&gan.MaxpoolLayer{
+			KernelHeight: 2,
+			KernelWidth:  2,
+			Padding:      []int{0, 0},
+			Stride:       []int{2, 2},
+		},
+		&gan.Conv2DLayer{
+			WeightNode:   gen_w1,
+			Activation:   gan.Rectify,
+			KernelHeight: 3,
+			KernelWidth:  3,
+			Padding:      []int{0, 0},
+			Stride:       []int{1, 1},
+			Dilation:     []int{1, 1},
+		},
+		&gan.DropoutLayer{
+			Probability: 0.5,
+		},
+		&gan.MaxpoolLayer{
+			KernelHeight: 2,
+			KernelWidth:  2,
+			Padding:      []int{0, 0},
+			Stride:       []int{2, 2},
+		},
+		&gan.Conv2DLayer{
+			WeightNode:   gen_w2,
+			Activation:   gan.Rectify,
+			KernelHeight: 3,
+			KernelWidth:  3,
+			Padding:      []int{0, 0},
+			Stride:       []int{1, 1},
+			Dilation:     []int{1, 1},
+		},
+		&gan.DropoutLayer{
+			Probability: 0.2,
+		},
+		&gan.MaxpoolLayer{
+			KernelHeight: 2,
+			KernelWidth:  2,
+			Padding:      []int{0, 0},
+			Stride:       []int{2, 2},
+		},
+		&gan.Conv2DLayer{
+			WeightNode:   gen_w3,
+			Activation:   gan.Rectify,
+			KernelHeight: 3,
+			KernelWidth:  3,
+			Padding:      []int{0, 0},
+			Stride:       []int{1, 1},
+			Dilation:     []int{1, 1},
+		},
+		&gan.DropoutLayer{
+			Probability: 0.2,
+		},
+		&gan.MaxpoolLayer{
+			KernelHeight: 2,
+			KernelWidth:  2,
+			Padding:      []int{0, 0},
+			Stride:       []int{2, 2},
+		},
+		&gan.FlattenLayer{},
+		&gan.LinearLayer{
+			WeightNode: gen_w4,
+			Activation: gan.Sigmoid,
+		},
+		&gan.LinearLayer{
+			WeightNode: gen_w5,
+			Activation: gan.Sigmoid,
+		},
+		&gan.ReshapeLayer{
+			Dims: []int{1, 1, imgHeight, imgWidth},
+		},
 	)
 	return generator
 }

--- a/cmd/examples/generate_symbol/main.go
+++ b/cmd/examples/generate_symbol/main.go
@@ -326,38 +326,31 @@ func defineDiscriminator(g *gorgonia.ExprGraph) *gan.DiscriminatorNet {
 	dis_w5 := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(dis_shp5...), gorgonia.WithName("discriminator_train_w5"), gorgonia.WithInit(gorgonia.GlorotN(1.0)))
 
 	discriminator := gan.Discriminator(
-		[]*gan.Layer{
-			{
-				WeightNode: dis_w0,
-				BiasNode:   dis_b0,
-				Type:       gan.LayerLinear,
-				Activation: gan.Sigmoid,
-			},
-			{
-				WeightNode: dis_w1,
-				BiasNode:   dis_b1,
-				Type:       gan.LayerLinear,
-				Activation: gan.Sigmoid,
-			},
-			{
-				WeightNode: dis_w2,
-				BiasNode:   dis_b2,
-				Type:       gan.LayerLinear,
-				Activation: gan.Sigmoid,
-			},
-			{
-				WeightNode: dis_w3,
-				BiasNode:   dis_b3,
-				Type:       gan.LayerLinear,
-				Activation: gan.Sigmoid,
-			},
-			{
-				WeightNode: dis_w5,
-				BiasNode:   dis_b5,
-				Type:       gan.LayerLinear,
-				Activation: gan.Sigmoid,
-			},
-		}...,
+		&gan.LinearLayer{
+			WeightNode: dis_w0,
+			BiasNode:   dis_b0,
+			Activation: gan.Sigmoid,
+		},
+		&gan.LinearLayer{
+			WeightNode: dis_w1,
+			BiasNode:   dis_b1,
+			Activation: gan.Sigmoid,
+		},
+		&gan.LinearLayer{
+			WeightNode: dis_w2,
+			BiasNode:   dis_b2,
+			Activation: gan.Sigmoid,
+		},
+		&gan.LinearLayer{
+			WeightNode: dis_w3,
+			BiasNode:   dis_b3,
+			Activation: gan.Sigmoid,
+		},
+		&gan.LinearLayer{
+			WeightNode: dis_w5,
+			BiasNode:   dis_b5,
+			Activation: gan.Sigmoid,
+		},
 	)
 	return discriminator
 }
@@ -380,32 +373,26 @@ func defineGenerator(g *gorgonia.ExprGraph) *gan.GeneratorNet {
 	gen_w3 := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(gen_shp3...), gorgonia.WithName("generator_w3"), gorgonia.WithInit(gorgonia.GlorotN(1.0)))
 
 	generator := gan.Generator(
-		[]*gan.Layer{
-			{
-				WeightNode: gen_w0,
-				BiasNode:   gen_b0,
-				Type:       gan.LayerLinear,
-				Activation: gan.Sigmoid,
-			},
-			{
-				WeightNode: gen_w1,
-				BiasNode:   gen_b1,
-				Type:       gan.LayerLinear,
-				Activation: gan.Sigmoid,
-			},
-			{
-				WeightNode: gen_w2,
-				BiasNode:   gen_b2,
-				Type:       gan.LayerLinear,
-				Activation: gan.Sigmoid,
-			},
-			{
-				WeightNode: gen_w3,
-				BiasNode:   gen_b3,
-				Type:       gan.LayerLinear,
-				Activation: gan.Sigmoid,
-			},
-		}...,
+		&gan.LinearLayer{
+			WeightNode: gen_w0,
+			BiasNode:   gen_b0,
+			Activation: gan.Sigmoid,
+		},
+		&gan.LinearLayer{
+			WeightNode: gen_w1,
+			BiasNode:   gen_b1,
+			Activation: gan.Sigmoid,
+		},
+		&gan.LinearLayer{
+			WeightNode: gen_w2,
+			BiasNode:   gen_b2,
+			Activation: gan.Sigmoid,
+		},
+		&gan.LinearLayer{
+			WeightNode: gen_w3,
+			BiasNode:   gen_b3,
+			Activation: gan.Sigmoid,
+		},
 	)
 
 	return generator

--- a/cmd/examples/parabola/main.go
+++ b/cmd/examples/parabola/main.go
@@ -316,32 +316,26 @@ func defineDiscriminator(g *gorgonia.ExprGraph) *gan.DiscriminatorNet {
 	dis_w3 := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(dis_shp3...), gorgonia.WithName("discriminator_train_w3"), gorgonia.WithInit(gorgonia.GlorotN(1.0)))
 
 	discriminator := gan.Discriminator(
-		[]*gan.Layer{
-			{
-				WeightNode: dis_w0,
-				BiasNode:   dis_b0,
-				Type:       gan.LayerLinear,
-				Activation: gan.Rectify,
-			},
-			{
-				WeightNode: dis_w1,
-				BiasNode:   dis_b1,
-				Type:       gan.LayerLinear,
-				Activation: gan.Rectify,
-			},
-			{
-				WeightNode: dis_w2,
-				BiasNode:   dis_b2,
-				Type:       gan.LayerLinear,
-				Activation: gan.Rectify,
-			},
-			{
-				WeightNode: dis_w3,
-				BiasNode:   dis_b3,
-				Type:       gan.LayerLinear,
-				Activation: gan.Sigmoid,
-			},
-		}...,
+		&gan.LinearLayer{
+			WeightNode: dis_w0,
+			BiasNode:   dis_b0,
+			Activation: gan.Rectify,
+		},
+		&gan.LinearLayer{
+			WeightNode: dis_w1,
+			BiasNode:   dis_b1,
+			Activation: gan.Rectify,
+		},
+		&gan.LinearLayer{
+			WeightNode: dis_w2,
+			BiasNode:   dis_b2,
+			Activation: gan.Rectify,
+		},
+		&gan.LinearLayer{
+			WeightNode: dis_w3,
+			BiasNode:   dis_b3,
+			Activation: gan.Sigmoid,
+		},
 	)
 	return discriminator
 }
@@ -360,26 +354,21 @@ func defineGenerator(g *gorgonia.ExprGraph) *gan.GeneratorNet {
 	gen_w2 := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(gen_shp2...), gorgonia.WithName("generator_w2"), gorgonia.WithInit(gorgonia.GlorotN(1.0)))
 
 	generator := gan.Generator(
-		[]*gan.Layer{
-			{
-				WeightNode: gen_w0,
-				BiasNode:   gen_b0,
-				Type:       gan.LayerLinear,
-				Activation: gan.Rectify,
-			},
-			{
-				WeightNode: gen_w1,
-				BiasNode:   gen_b1,
-				Type:       gan.LayerLinear,
-				Activation: gan.Rectify,
-			},
-			{
-				WeightNode: gen_w2,
-				BiasNode:   gen_b2,
-				Type:       gan.LayerLinear,
-				Activation: gan.NoActivation,
-			},
-		}...,
+		&gan.LinearLayer{
+			WeightNode: gen_w0,
+			BiasNode:   gen_b0,
+			Activation: gan.Rectify,
+		},
+		&gan.LinearLayer{
+			WeightNode: gen_w1,
+			BiasNode:   gen_b1,
+			Activation: gan.Rectify,
+		},
+		&gan.LinearLayer{
+			WeightNode: gen_w2,
+			BiasNode:   gen_b2,
+			Activation: gan.NoActivation,
+		},
 	)
 
 	return generator

--- a/cmd/examples/sin/main.go
+++ b/cmd/examples/sin/main.go
@@ -320,37 +320,31 @@ func defineDiscriminator(g *gorgonia.ExprGraph) *gan.DiscriminatorNet {
 	dis_w5 := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(dis_shp5...), gorgonia.WithName("discriminator_train_w5"), gorgonia.WithInit(gorgonia.GlorotN(1.0)))
 
 	discriminator := gan.Discriminator(
-		[]*gan.Layer{
-			{
-				WeightNode: dis_w0,
-				BiasNode:   dis_b0,
-				Type:       gan.LayerLinear,
-				Activation: gan.Rectify,
-			},
-			{
-				WeightNode: dis_w1,
-				BiasNode:   dis_b1,
-				Type:       gan.LayerLinear,
-				Activation: gan.Rectify,
-			},
-			{
-				WeightNode: dis_w2,
-				BiasNode:   dis_b2,
-				Type:       gan.LayerLinear,
-				Activation: gan.Rectify,
-			},
-			{
-				WeightNode: dis_w3,
-				BiasNode:   dis_b3,
-				Type:       gan.LayerLinear,
-				Activation: gan.Rectify,
-			},
-			{
-				WeightNode: dis_w5,
-				BiasNode:   dis_b5,
-				Activation: gan.Sigmoid,
-			},
-		}...,
+		&gan.LinearLayer{
+			WeightNode: dis_w0,
+			BiasNode:   dis_b0,
+			Activation: gan.Rectify,
+		},
+		&gan.LinearLayer{
+			WeightNode: dis_w1,
+			BiasNode:   dis_b1,
+			Activation: gan.Rectify,
+		},
+		&gan.LinearLayer{
+			WeightNode: dis_w2,
+			BiasNode:   dis_b2,
+			Activation: gan.Rectify,
+		},
+		&gan.LinearLayer{
+			WeightNode: dis_w3,
+			BiasNode:   dis_b3,
+			Activation: gan.Rectify,
+		},
+		&gan.LinearLayer{
+			WeightNode: dis_w5,
+			BiasNode:   dis_b5,
+			Activation: gan.Sigmoid,
+		},
 	)
 	return discriminator
 }
@@ -373,32 +367,26 @@ func defineGenerator(g *gorgonia.ExprGraph) *gan.GeneratorNet {
 	gen_w3 := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(gen_shp3...), gorgonia.WithName("generator_w3"), gorgonia.WithInit(gorgonia.GlorotN(1.0)))
 
 	generator := gan.Generator(
-		[]*gan.Layer{
-			{
-				WeightNode: gen_w0,
-				BiasNode:   gen_b0,
-				Type:       gan.LayerLinear,
-				Activation: gan.Rectify,
-			},
-			{
-				WeightNode: gen_w1,
-				BiasNode:   gen_b1,
-				Type:       gan.LayerLinear,
-				Activation: gan.Rectify,
-			},
-			{
-				WeightNode: gen_w2,
-				BiasNode:   gen_b2,
-				Type:       gan.LayerLinear,
-				Activation: gan.Rectify,
-			},
-			{
-				WeightNode: gen_w3,
-				BiasNode:   gen_b3,
-				Type:       gan.LayerLinear,
-				Activation: gan.NoActivation,
-			},
-		}...,
+		&gan.LinearLayer{
+			WeightNode: gen_w0,
+			BiasNode:   gen_b0,
+			Activation: gan.Rectify,
+		},
+		&gan.LinearLayer{
+			WeightNode: gen_w1,
+			BiasNode:   gen_b1,
+			Activation: gan.Rectify,
+		},
+		&gan.LinearLayer{
+			WeightNode: gen_w2,
+			BiasNode:   gen_b2,
+			Activation: gan.Rectify,
+		},
+		&gan.LinearLayer{
+			WeightNode: gen_w3,
+			BiasNode:   gen_b3,
+			Activation: gan.NoActivation,
+		},
 	)
 	return generator
 }

--- a/cmd/examples/train_cnn/main.go
+++ b/cmd/examples/train_cnn/main.go
@@ -278,47 +278,29 @@ func defineCNN(g *gorgonia.ExprGraph) *gan.DiscriminatorNet {
 	dis_shp1 := tensor.Shape{3, 45}
 	dis_w1 := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(dis_shp1...), gorgonia.WithName("discriminator_train_w1"), gorgonia.WithInit(gorgonia.GlorotN(1.0)))
 	discriminator := gan.Discriminator(
-		[]*gan.Layer{
-			{
-				WeightNode: dis_w0,
-				BiasNode:   nil,
-				Type:       gan.LayerConvolutional,
-				Activation: gan.Rectify,
-				Options: &gan.Options{
-					KernelHeight: 3,
-					KernelWidth:  3,
-					Padding:      []int{0, 0},
-					Stride:       []int{1, 1},
-					Dilation:     []int{1, 1},
-				},
-			},
-			{
-				Type: gan.LayerDropout,
-				Options: &gan.Options{
-					Probability: 0.3,
-				},
-			},
-			{
-				Type:       gan.LayerMaxpool,
-				Activation: gan.NoActivation,
-				Options: &gan.Options{
-					KernelHeight: 2,
-					KernelWidth:  2,
-					Padding:      []int{0, 0},
-					Stride:       []int{2, 2},
-				},
-			},
-			{
-				Type:       gan.LayerFlatten,
-				Activation: gan.NoActivation,
-			},
-			{
-				WeightNode: dis_w1,
-				BiasNode:   nil,
-				Type:       gan.LayerLinear,
-				Activation: gan.Sigmoid,
-			},
-		}...,
+		&gan.Conv2DLayer{
+			WeightNode:   dis_w0,
+			Activation:   gan.Rectify,
+			KernelHeight: 3,
+			KernelWidth:  3,
+			Padding:      []int{0, 0},
+			Stride:       []int{1, 1},
+			Dilation:     []int{1, 1},
+		},
+		&gan.DropoutLayer{
+			Probability: 0.3,
+		},
+		&gan.MaxpoolLayer{
+			KernelHeight: 2,
+			KernelWidth:  2,
+			Padding:      []int{0, 0},
+			Stride:       []int{2, 2},
+		},
+		&gan.FlattenLayer{},
+		&gan.LinearLayer{
+			WeightNode: dis_w1,
+			Activation: gan.Sigmoid,
+		},
 	)
 	return discriminator
 }

--- a/cmd/examples/train_embedding/main.go
+++ b/cmd/examples/train_embedding/main.go
@@ -233,25 +233,15 @@ func defineNet(g *gorgonia.ExprGraph, vocabulary, maxWords, embeddingDim int) *g
 	dis_shp1 := tensor.Shape{1, maxWords * embeddingDim}
 	dis_w1 := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(dis_shp1...), gorgonia.WithName("discriminator_train_w1"), gorgonia.WithInit(gorgonia.GlorotN(1.0)))
 	discriminator := gan.Discriminator(
-		[]*gan.Layer{
-			{
-				WeightNode: dis_w0,
-				BiasNode:   nil,
-				Type:       gan.LayerEmbedding,
-				Options: &gan.Options{
-					EmbeddingSize: embeddingDim,
-				},
-			},
-			{
-				Type: gan.LayerFlatten,
-			},
-			{
-				WeightNode: dis_w1,
-				BiasNode:   nil,
-				Type:       gan.LayerLinear,
-				Activation: gan.Sigmoid,
-			},
-		}...,
+		&gan.EmbeddingLayer{
+			WeightNode:    dis_w0,
+			EmbeddingSize: embeddingDim,
+		},
+		&gan.FlattenLayer{},
+		&gan.LinearLayer{
+			WeightNode: dis_w1,
+			Activation: gan.Sigmoid,
+		},
 	)
 	return discriminator
 }

--- a/discriminator.go
+++ b/discriminator.go
@@ -9,13 +9,12 @@ import (
 //
 // Layers - simple sequence of layers
 // out - alias to activated output of last layer
-//
 type DiscriminatorNet struct {
 	private *Network
 }
 
 // Discriminator Constructor for DiscriminatorNet
-func Discriminator(Layers ...*Layer) *DiscriminatorNet {
+func Discriminator(Layers ...Layer) *DiscriminatorNet {
 	return &DiscriminatorNet{private: &Network{
 		Name:   "discriminator",
 		Layers: Layers,
@@ -36,7 +35,6 @@ func (net *DiscriminatorNet) Learnables() gorgonia.Nodes {
 //
 // input - Input node (or nodes)
 // batchSize - batch size. If it's >= 2 then broadcast function will be applied
-//
 func (net *DiscriminatorNet) Fwd(batchSize int, inputs ...*gorgonia.Node) error {
 	if err := net.private.Fwd(batchSize, inputs...); err != nil {
 		return errors.Wrap(err, "[Discriminator]")

--- a/gan.go
+++ b/gan.go
@@ -15,15 +15,15 @@ import (
 //
 // Note on the weights of modifiedDiscriminator (the "shared memory" trick):
 // Gorgonia does not provide a way to "freeze" a subset of learnables, so the Discriminator
-// is defined on its own graph (where it is trained) and its structure is copied into the GAN's graph.
-// Each copied node is created with gorgonia.WithValue(originalNode.Value()) which binds the SAME
+// is defined on its own graph (where it is trained) and its structure is copied into the GAN's graph
+// via CloneTo(...) method of Layer interface.
+// Each copied learnable node is created with gorgonia.WithValue(originalNode.Value()) which binds the SAME
 // underlying tensor (same backing memory) to both nodes — it is NOT a deep copy.
 // Since Gorgonia's solvers update weights in-place, every training step of the Discriminator
 // on its own graph is immediately "visible" to the copied nodes in the GAN's graph.
 // So there is no need to manually sync weights between the two graphs.
 // During the Generator's training step the solver is given GeneratorLearnables() only,
 // therefore the Discriminator's copies stay untouched (they act as constants w.r.t. the update).
-//
 type GAN struct {
 	generatorPart     *GeneratorNet
 	discriminatorPart *DiscriminatorNet
@@ -35,51 +35,33 @@ type GAN struct {
 	learnablesGen gorgonia.Nodes
 }
 
+// NewGAN Constructor for GAN.
+//
+// g - graph where Generator is defined (GAN's copy of Discriminator will be defined on the same graph)
+// definedGenerator - reference to Generator
+// definedDiscriminator - reference to Discriminator (could be defined on any graph)
 func NewGAN(g *gorgonia.ExprGraph, definedGenerator *GeneratorNet, definedDiscriminator *DiscriminatorNet) (*GAN, error) {
 	definedGAN := GAN{
 		generatorPart:     definedGenerator,
 		discriminatorPart: definedDiscriminator,
 		modifiedDiscriminator: &DiscriminatorNet{private: &Network{
 			Name:   "gan_discriminator",
-			Layers: make([]*Layer, len(definedDiscriminator.private.Layers)),
+			Layers: make([]Layer, len(definedDiscriminator.private.Layers)),
 		}},
 		learnablesGen: definedGenerator.Learnables(),
 		learnables:    definedGenerator.Learnables(),
 	}
 	// Discriminator part for GAN
 	for i, l := range definedDiscriminator.private.Layers {
-		definedGAN.modifiedDiscriminator.private.Layers[i] = &Layer{
-			Activation: l.Activation,
-			Type:       l.Type,
+		if l == nil {
+			return nil, fmt.Errorf("Discriminator's Layer %d is nil", i)
 		}
-		if l.Options != nil {
-			definedGAN.modifiedDiscriminator.private.Layers[i].Options = &Options{
-				KernelHeight:  l.Options.KernelHeight,
-				KernelWidth:   l.Options.KernelWidth,
-				Padding:       l.Options.Padding,
-				Stride:        l.Options.Stride,
-				Dilation:      l.Options.Dilation,
-				ReshapeDims:   l.Options.ReshapeDims,
-				Probability:   l.Options.Probability,
-				EmbeddingSize: l.Options.EmbeddingSize,
-				Axis:          l.Options.Axis,
-			}
+		clonedLayer, err := l.CloneTo(g, "_gan")
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("Can't clone Discriminator's Layer %d onto GAN's graph", i))
 		}
-		if l.WeightNode == nil && !noWeightsAllowed(l.Type) {
-			return nil, fmt.Errorf("Discriminator's Layer %d has nil weight node", i)
-		}
-		if l.WeightNode != nil {
-			// WithValue(...) below binds the very same tensor as the original node has.
-			// Backing memory is shared, so in-place updates done by a solver on the
-			// Discriminator's own graph automatically propagate here. See note above.
-			definedGAN.modifiedDiscriminator.private.Layers[i].WeightNode = gorgonia.NewTensor(g, l.WeightNode.Dtype(), l.WeightNode.Dims(), gorgonia.WithShape(l.WeightNode.Shape()...), gorgonia.WithName(l.WeightNode.Name()+"_gan"), gorgonia.WithValue(l.WeightNode.Value()))
-			definedGAN.learnables = append(definedGAN.learnables, definedGAN.modifiedDiscriminator.private.Layers[i].WeightNode)
-		}
-		if l.BiasNode != nil {
-			definedGAN.modifiedDiscriminator.private.Layers[i].BiasNode = gorgonia.NewTensor(g, l.BiasNode.Dtype(), l.BiasNode.Dims(), gorgonia.WithShape(l.BiasNode.Shape()...), gorgonia.WithName(l.BiasNode.Name()+"_gan"), gorgonia.WithValue(l.BiasNode.Value()))
-			definedGAN.learnables = append(definedGAN.learnables, definedGAN.modifiedDiscriminator.private.Layers[i].BiasNode)
-		}
-
+		definedGAN.modifiedDiscriminator.private.Layers[i] = clonedLayer
+		definedGAN.learnables = append(definedGAN.learnables, clonedLayer.Learnables()...)
 	}
 	return &definedGAN, nil
 }
@@ -108,7 +90,6 @@ func (net *GAN) GeneratorLearnables() gorgonia.Nodes {
 //
 // batchSize - batch size. If it's >= 2 then broadcast function will be applied
 // Note: input node is not needed since input for Discriminator is just Generator's output
-//
 func (net *GAN) Fwd(batchSize int) error {
 	if err := net.modifiedDiscriminator.Fwd(batchSize, net.generatorPart.Out()); err != nil {
 		return errors.Wrap(err, "[GAN, Discriminator part]")

--- a/generator.go
+++ b/generator.go
@@ -9,13 +9,12 @@ import (
 //
 // Layers - simple sequence of layers
 // out - alias to activated output of last layer
-//
 type GeneratorNet struct {
 	private *Network
 }
 
 // Generator Constructor for GeneratorNet
-func Generator(Layers ...*Layer) *GeneratorNet {
+func Generator(Layers ...Layer) *GeneratorNet {
 	return &GeneratorNet{private: &Network{
 		Name:   "generator",
 		Layers: Layers,
@@ -36,7 +35,6 @@ func (net *GeneratorNet) Learnables() gorgonia.Nodes {
 //
 // input - Input node (or nodes)
 // batchSize - batch size. If it's >= 2 then broadcast function will be applied
-//
 func (net *GeneratorNet) Fwd(batchSize int, inputs ...*gorgonia.Node) error {
 	if err := net.private.Fwd(batchSize, inputs...); err != nil {
 		return errors.Wrap(err, "[Generator]")

--- a/layer.go
+++ b/layer.go
@@ -5,73 +5,78 @@ import (
 
 	"github.com/pkg/errors"
 	"gorgonia.org/gorgonia"
-	"gorgonia.org/tensor"
 )
 
-// Layer Just an alias to Weight+Bias+ActivationFunction combo
-type Layer struct {
-	WeightNode *gorgonia.Node
-	BiasNode   *gorgonia.Node
-	Activation ActivationFunc
-	Type       LayerType
-
-	outputNonActivatedNode *gorgonia.Node
-	outputActivatedNode    *gorgonia.Node
-	extraNodes             []*gorgonia.Node
-	Options                *Options
+// Layer Interface for a single layer of a neural network.
+//
+// Fwd - Builds forward pass for provided inputs and returns non-activated output node
+// Activate - Applies layer's activation function to non-activated output node.
+//
+//	Layers which do not imply activation (e.g. Flatten/Reshape/Dropout/Embedding) just return input node as is.
+//
+// Learnables - Returns nodes containing learnable parameters (could be empty)
+// CloneTo - Copies layer structure onto the provided graph.
+//
+//	Learnable nodes of the copy are new nodes bound to THE SAME underlying tensors,
+//	see notes for NewGAN in gan.go about this shared-memory trick.
+type Layer interface {
+	Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error)
+	Activate(input *gorgonia.Node) (*gorgonia.Node, error)
+	Learnables() gorgonia.Nodes
+	CloneTo(g *gorgonia.ExprGraph, nameSuffix string) (Layer, error)
 }
 
-// Options Struct for holding options for certain activation functions.
-// LayerOptions Struct for holding options for different layers' types
-
-type Options struct {
-	// Used in layers: [Conv2D, Maxpool2D]
-	KernelHeight int
-	// Used in layers: [Conv2D, Maxpool2D]
-	KernelWidth int
-	// Used in layers: [Conv2D, Maxpool2D]
-	Padding []int
-	// Used in layers: [Conv2D, Maxpool2D]
-	Stride []int
-	// Used in layers: [Conv2D, Maxpool2D]
-	Dilation []int
-	// Used in layers: [Reshape]
-	ReshapeDims []int
-	// Used in layers: [Dropout]
-	Probability float64
-	// Used in layers: [Embedding]
-	EmbeddingSize int
-	// Not used in layers directly. But used for defining parametetrs for certain activation functions (e.g. Softmax)
-	Axis []int
-}
-
-type LayerType uint16
-
-const (
-	LayerLinear = LayerType(iota)
-	LayerFlatten
-	LayerConvolutional
-	LayerMaxpool
-	LayerReshape
-	LayerDropout
-	LayerEmbedding
-)
-
-var (
-	allowedNoWeights = []LayerType{LayerMaxpool, LayerFlatten, LayerReshape, LayerDropout}
-)
-
-func noWeightsAllowed(checkType LayerType) bool {
-	return checkLayerType(checkType, allowedNoWeights...)
-}
-
-func checkLayerType(checkType LayerType, t ...LayerType) bool {
-	for _, typeOf := range t {
-		if checkType == typeOf {
-			return true
-		}
+// singleInput Helper for layers which can handle only one input node
+func singleInput(layerType string, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
+	if len(inputs) == 0 {
+		return nil, fmt.Errorf("There are no input nodes for layer of type '%s'", layerType)
 	}
-	return false
+	if len(inputs) > 1 {
+		return nil, fmt.Errorf("Layer of type '%s' can handle only 1 input node, got %d", layerType, len(inputs))
+	}
+	return inputs[0], nil
+}
+
+// addBias Helper adding bias node to non-activated output of a layer.
+// If bias node is nil then non-activated output is returned as is.
+//
+// batchSize - batch size. If it's >= 2 then broadcast function will be applied
+func addBias(layerNonActivated, bias *gorgonia.Node, batchSize int) (*gorgonia.Node, error) {
+	if bias == nil {
+		return layerNonActivated, nil
+	}
+	if batchSize < 2 {
+		withBias, err := gorgonia.Add(layerNonActivated, bias)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't add bias to non-activated output of a layer")
+		}
+		return withBias, nil
+	}
+	withBias, err := gorgonia.BroadcastAdd(layerNonActivated, bias, nil, []byte{0})
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("Can't add [in broadcast term with batch_size = %d] bias to non-activated output of a layer", batchSize))
+	}
+	return withBias, nil
+}
+
+// applyActivation Helper applying activation function. Nil function is considered to be NoActivation.
+func applyActivation(f ActivationFunc, input *gorgonia.Node) (*gorgonia.Node, error) {
+	if f == nil {
+		return input, nil
+	}
+	return f(input)
+}
+
+// cloneLearnableTo Creates node on the provided graph copying dtype/shape/name (with suffix) of the source node.
+//
+// Important: gorgonia.WithValue(...) binds the very same tensor as the source node has.
+// Backing memory is shared, so in-place updates done by a solver on the source graph
+// automatically propagate to the copy. See notes for NewGAN in gan.go.
+func cloneLearnableTo(g *gorgonia.ExprGraph, node *gorgonia.Node, nameSuffix string) *gorgonia.Node {
+	if node == nil {
+		return nil
+	}
+	return gorgonia.NewTensor(g, node.Dtype(), node.Dims(), gorgonia.WithShape(node.Shape()...), gorgonia.WithName(node.Name()+nameSuffix), gorgonia.WithValue(node.Value()))
 }
 
 func checkF64ValueInRange(input, min, max float64) bool {
@@ -79,156 +84,4 @@ func checkF64ValueInRange(input, min, max float64) bool {
 		return false
 	}
 	return true
-}
-
-// Fwd Initializates feedforward for provided input
-//
-// inputs - Input node (or nodes)
-// batchSize - batch size. If it's >= 2 then broadcast function will be applied
-//
-func (layer *Layer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
-	var err error
-	var layerNonActivated *gorgonia.Node
-
-	if len(inputs) == 0 {
-		return nil, fmt.Errorf("There are no input nodes for layer")
-	}
-
-	if layer.WeightNode == nil && !noWeightsAllowed(layer.Type) {
-		return nil, fmt.Errorf("Layer's weights node is nil")
-	}
-// @todo: I guess it's better to have interfaces or personalized methods
-	switch layer.Type {
-	case LayerLinear:
-		if len(inputs) > 1 {
-			return nil, fmt.Errorf("Layer's type '%d' can handle only 1 input node, got %d", layer.Type, len(inputs))
-		}
-		input := inputs[0]
-		tOp, err := gorgonia.Transpose(layer.WeightNode)
-		if err != nil {
-			return nil, errors.Wrap(err, "Can't transpose weights of layer")
-		}
-		if batchSize < 2 {
-			layerNonActivated, err = gorgonia.Mul(input, tOp)
-			if err != nil {
-				return nil, errors.Wrap(err, "Can't multiply input and weights of layer [batch_size = 1]")
-			}
-		} else {
-			layerNonActivated, err = gorgonia.BatchedMatMul(input, tOp)
-			if err != nil {
-				return nil, errors.Wrap(err, fmt.Sprintf("Can't multiply input and weights of layer [batch_size = %d]", batchSize))
-			}
-		}
-	case LayerConvolutional:
-		if len(inputs) > 1 {
-			return nil, fmt.Errorf("Layer's type '%d' can handle only 1 input node, got %d", layer.Type, len(inputs))
-		}
-		input := inputs[0]
-		if layer.Options == nil {
-			return nil, fmt.Errorf("Options haven't been provided for layer")
-		}
-		layerNonActivated, err = gorgonia.Conv2d(input, layer.WeightNode, tensor.Shape{layer.Options.KernelHeight, layer.Options.KernelWidth}, layer.Options.Padding, layer.Options.Stride, layer.Options.Dilation)
-		if err != nil {
-			return nil, errors.Wrap(err, "Can't convolve[2D] input by kernel of layer")
-		}
-	case LayerMaxpool:
-		if len(inputs) > 1 {
-			return nil, fmt.Errorf("Layer's type '%d' can handle only 1 input node, got %d", layer.Type, len(inputs))
-		}
-		input := inputs[0]
-		if layer.Options == nil {
-			return nil, fmt.Errorf("Options haven't been provided for layer")
-		}
-		layerNonActivated, err = gorgonia.MaxPool2D(input, tensor.Shape{layer.Options.KernelHeight, layer.Options.KernelWidth}, layer.Options.Padding, layer.Options.Stride)
-		if err != nil {
-			return nil, errors.Wrap(err, "Can't maxpool[2D] input by kernel of layer")
-		}
-	case LayerFlatten:
-		if len(inputs) > 1 {
-			return nil, fmt.Errorf("Layer's type '%d' can handle only 1 input node, got %d", layer.Type, len(inputs))
-		}
-		input := inputs[0]
-		// Help developers to not provide NoActivation for flatten layer
-		layer.Activation = NoActivation
-		layerNonActivated, err = gorgonia.Reshape(input, tensor.Shape{batchSize, input.Shape().TotalSize() / batchSize})
-		if err != nil {
-			return nil, errors.Wrap(err, "Can't flatten input of layer")
-		}
-	case LayerReshape:
-		if len(inputs) > 1 {
-			return nil, fmt.Errorf("Layer's type '%d' can handle only 1 input node, got %d", layer.Type, len(inputs))
-		}
-		input := inputs[0]
-		if layer.Options == nil {
-			return nil, fmt.Errorf("Options haven't been provided for layer")
-		}
-		// Help developers to not provide NoActivation for reshaping layer
-		layer.Activation = NoActivation
-		layerNonActivated, err = gorgonia.Reshape(input, layer.Options.ReshapeDims)
-		if err != nil {
-			return nil, errors.Wrap(err, "Can't reshape input of layer")
-		}
-	case LayerDropout:
-		if len(inputs) > 1 {
-			return nil, fmt.Errorf("Layer's type '%d' can handle only 1 input node, got %d", layer.Type, len(inputs))
-		}
-		input := inputs[0]
-		if layer.Options == nil {
-			return nil, fmt.Errorf("Options haven't been provided for layer")
-		}
-		// Help developers to not provide NoActivation for dropout layer
-		layer.Activation = NoActivation
-		if ok := checkF64ValueInRange(layer.Options.Probability, 0.0, 1.0); !ok {
-			return nil, fmt.Errorf("Dropout probability should lie in [0;1] for layer. Got %f", layer.Options.Probability)
-		}
-		layerNonActivated, err = gorgonia.Dropout(input, layer.Options.Probability)
-		if err != nil {
-			return nil, errors.Wrap(err, "Can't dilute input of layer")
-		}
-	case LayerEmbedding:
-		if len(inputs) > 1 {
-			return nil, fmt.Errorf("Layer's type '%d' can handle only 1 input node, got %d", layer.Type, len(inputs))
-		}
-		input := inputs[0]
-		if layer.Options == nil {
-			return nil, fmt.Errorf("Options haven't been provided for layer")
-		}
-		if input.Type().String() != "Vector int" {
-			return nil, fmt.Errorf("Layer is implemented for type 'Int' not for '%s'", input.Type().String())
-		}
-		inputLength := input.Shape().TotalSize()
-		tmpFlatten, err := gorgonia.Reshape(input, tensor.Shape{inputLength})
-		if err != nil {
-			return nil, errors.Wrap(err, "Can't flatten input of layer [temporary]")
-		}
-		tmpEmbedding, err := gorgonia.ByIndices(layer.WeightNode, tmpFlatten, 0)
-		if err != nil {
-			return nil, errors.Wrap(err, "Can't embedd input of layer [temporary]")
-		}
-		// Help developers to not provide NoActivation for embedding layer
-		layer.Activation = NoActivation
-		layerNonActivated, err = gorgonia.Reshape(tmpEmbedding, append(input.Shape(), layer.Options.EmbeddingSize))
-		if err != nil {
-			return nil, errors.Wrap(err, "Can't embedd input of layer")
-		}
-	default:
-		return nil, fmt.Errorf("Layer's type '%d' (uint16) is not handled", layer.Type)
-	}
-
-	// Bias part
-	if layer.BiasNode != nil {
-		if batchSize < 2 {
-			layerNonActivated, err = gorgonia.Add(layerNonActivated, layer.BiasNode)
-			if err != nil {
-				return nil, errors.Wrap(err, "Can't add bias to non-activated output of a layer")
-			}
-		} else {
-			layerNonActivated, err = gorgonia.BroadcastAdd(layerNonActivated, layer.BiasNode, nil, []byte{0})
-			if err != nil {
-				return nil, errors.Wrap(err, fmt.Sprintf("Can't add [in broadcast term with batch_size = %d] bias to non-activated output of a layer", batchSize))
-			}
-		}
-	}
-	layer.outputNonActivatedNode = layerNonActivated
-	return layer.outputNonActivatedNode, nil
 }

--- a/layer_conv2d.go
+++ b/layer_conv2d.go
@@ -1,0 +1,74 @@
+package gan_go
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"gorgonia.org/gorgonia"
+	"gorgonia.org/tensor"
+)
+
+// Conv2DLayer 2D convolutional layer: activate(conv2d(input, W) + bias)
+type Conv2DLayer struct {
+	WeightNode *gorgonia.Node
+	BiasNode   *gorgonia.Node
+	Activation ActivationFunc
+
+	KernelHeight int
+	KernelWidth  int
+	Padding      []int
+	Stride       []int
+	Dilation     []int
+}
+
+// Fwd Initializates feedforward for provided input
+//
+// batchSize - batch size. If it's >= 2 then broadcast function will be applied for bias part
+func (layer *Conv2DLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
+	input, err := singleInput("conv2d", inputs...)
+	if err != nil {
+		return nil, err
+	}
+	if layer.WeightNode == nil {
+		return nil, fmt.Errorf("Convolutional layer's weights node is nil")
+	}
+	layerNonActivated, err := gorgonia.Conv2d(input, layer.WeightNode, tensor.Shape{layer.KernelHeight, layer.KernelWidth}, layer.Padding, layer.Stride, layer.Dilation)
+	if err != nil {
+		return nil, errors.Wrap(err, "Can't convolve[2D] input by kernel of layer")
+	}
+	return addBias(layerNonActivated, layer.BiasNode, batchSize)
+}
+
+// Activate Applies layer's activation function
+func (layer *Conv2DLayer) Activate(input *gorgonia.Node) (*gorgonia.Node, error) {
+	return applyActivation(layer.Activation, input)
+}
+
+// Learnables Returns learnable nodes
+func (layer *Conv2DLayer) Learnables() gorgonia.Nodes {
+	learnables := make(gorgonia.Nodes, 0, 2)
+	if layer.WeightNode != nil {
+		learnables = append(learnables, layer.WeightNode)
+	}
+	if layer.BiasNode != nil {
+		learnables = append(learnables, layer.BiasNode)
+	}
+	return learnables
+}
+
+// CloneTo Copies layer structure onto the provided graph. Learnables of the copy share underlying tensors with the source layer.
+func (layer *Conv2DLayer) CloneTo(g *gorgonia.ExprGraph, nameSuffix string) (Layer, error) {
+	if layer.WeightNode == nil {
+		return nil, fmt.Errorf("Convolutional layer has nil weight node")
+	}
+	return &Conv2DLayer{
+		WeightNode:   cloneLearnableTo(g, layer.WeightNode, nameSuffix),
+		BiasNode:     cloneLearnableTo(g, layer.BiasNode, nameSuffix),
+		Activation:   layer.Activation,
+		KernelHeight: layer.KernelHeight,
+		KernelWidth:  layer.KernelWidth,
+		Padding:      layer.Padding,
+		Stride:       layer.Stride,
+		Dilation:     layer.Dilation,
+	}, nil
+}

--- a/layer_dropout.go
+++ b/layer_dropout.go
@@ -1,0 +1,45 @@
+package gan_go
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"gorgonia.org/gorgonia"
+)
+
+// DropoutLayer Applies dropout to the input.
+// Has no learnable parameters and no activation.
+type DropoutLayer struct {
+	Probability float64
+}
+
+// Fwd Initializates feedforward for provided input
+func (layer *DropoutLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
+	input, err := singleInput("dropout", inputs...)
+	if err != nil {
+		return nil, err
+	}
+	if ok := checkF64ValueInRange(layer.Probability, 0.0, 1.0); !ok {
+		return nil, fmt.Errorf("Dropout probability should lie in [0;1] for layer. Got %f", layer.Probability)
+	}
+	diluted, err := gorgonia.Dropout(input, layer.Probability)
+	if err != nil {
+		return nil, errors.Wrap(err, "Can't dilute input of layer")
+	}
+	return diluted, nil
+}
+
+// Activate Dropout layer does not imply activation
+func (layer *DropoutLayer) Activate(input *gorgonia.Node) (*gorgonia.Node, error) {
+	return input, nil
+}
+
+// Learnables Returns learnable nodes. Dropout layer has no learnables.
+func (layer *DropoutLayer) Learnables() gorgonia.Nodes {
+	return gorgonia.Nodes{}
+}
+
+// CloneTo Copies layer structure onto the provided graph
+func (layer *DropoutLayer) CloneTo(g *gorgonia.ExprGraph, nameSuffix string) (Layer, error) {
+	return &DropoutLayer{Probability: layer.Probability}, nil
+}

--- a/layer_embedding.go
+++ b/layer_embedding.go
@@ -1,0 +1,68 @@
+package gan_go
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"gorgonia.org/gorgonia"
+	"gorgonia.org/tensor"
+)
+
+// EmbeddingLayer Looks up embeddings (rows of weight node) for integer input indices.
+// Input must be a vector of type Int. Has no activation.
+type EmbeddingLayer struct {
+	WeightNode    *gorgonia.Node
+	EmbeddingSize int
+}
+
+// Fwd Initializates feedforward for provided input
+func (layer *EmbeddingLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
+	input, err := singleInput("embedding", inputs...)
+	if err != nil {
+		return nil, err
+	}
+	if layer.WeightNode == nil {
+		return nil, fmt.Errorf("Embedding layer's weights node is nil")
+	}
+	if input.Type().String() != "Vector int" {
+		return nil, fmt.Errorf("Layer is implemented for type 'Int' not for '%s'", input.Type().String())
+	}
+	inputLength := input.Shape().TotalSize()
+	tmpFlatten, err := gorgonia.Reshape(input, tensor.Shape{inputLength})
+	if err != nil {
+		return nil, errors.Wrap(err, "Can't flatten input of layer [temporary]")
+	}
+	tmpEmbedding, err := gorgonia.ByIndices(layer.WeightNode, tmpFlatten, 0)
+	if err != nil {
+		return nil, errors.Wrap(err, "Can't embedd input of layer [temporary]")
+	}
+	embedding, err := gorgonia.Reshape(tmpEmbedding, append(input.Shape(), layer.EmbeddingSize))
+	if err != nil {
+		return nil, errors.Wrap(err, "Can't embedd input of layer")
+	}
+	return embedding, nil
+}
+
+// Activate Embedding layer does not imply activation
+func (layer *EmbeddingLayer) Activate(input *gorgonia.Node) (*gorgonia.Node, error) {
+	return input, nil
+}
+
+// Learnables Returns learnable nodes
+func (layer *EmbeddingLayer) Learnables() gorgonia.Nodes {
+	if layer.WeightNode != nil {
+		return gorgonia.Nodes{layer.WeightNode}
+	}
+	return gorgonia.Nodes{}
+}
+
+// CloneTo Copies layer structure onto the provided graph. Learnables of the copy share underlying tensors with the source layer.
+func (layer *EmbeddingLayer) CloneTo(g *gorgonia.ExprGraph, nameSuffix string) (Layer, error) {
+	if layer.WeightNode == nil {
+		return nil, fmt.Errorf("Embedding layer has nil weight node")
+	}
+	return &EmbeddingLayer{
+		WeightNode:    cloneLearnableTo(g, layer.WeightNode, nameSuffix),
+		EmbeddingSize: layer.EmbeddingSize,
+	}, nil
+}

--- a/layer_flatten.go
+++ b/layer_flatten.go
@@ -1,0 +1,40 @@
+package gan_go
+
+import (
+	"github.com/pkg/errors"
+	"gorgonia.org/gorgonia"
+	"gorgonia.org/tensor"
+)
+
+// FlattenLayer Represents input tensor as [batchSize x Total number of elements in tensor / batchSize].
+// Has no learnable parameters and no activation.
+type FlattenLayer struct {
+}
+
+// Fwd Initializates feedforward for provided input
+func (layer *FlattenLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
+	input, err := singleInput("flatten", inputs...)
+	if err != nil {
+		return nil, err
+	}
+	flatten, err := gorgonia.Reshape(input, tensor.Shape{batchSize, input.Shape().TotalSize() / batchSize})
+	if err != nil {
+		return nil, errors.Wrap(err, "Can't flatten input of layer")
+	}
+	return flatten, nil
+}
+
+// Activate Flatten layer does not imply activation
+func (layer *FlattenLayer) Activate(input *gorgonia.Node) (*gorgonia.Node, error) {
+	return input, nil
+}
+
+// Learnables Returns learnable nodes. Flatten layer has no learnables.
+func (layer *FlattenLayer) Learnables() gorgonia.Nodes {
+	return gorgonia.Nodes{}
+}
+
+// CloneTo Copies layer structure onto the provided graph
+func (layer *FlattenLayer) CloneTo(g *gorgonia.ExprGraph, nameSuffix string) (Layer, error) {
+	return &FlattenLayer{}, nil
+}

--- a/layer_linear.go
+++ b/layer_linear.go
@@ -1,0 +1,74 @@
+package gan_go
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"gorgonia.org/gorgonia"
+)
+
+// LinearLayer Fully connected layer: activate(input × Wᵀ + bias)
+type LinearLayer struct {
+	WeightNode *gorgonia.Node
+	BiasNode   *gorgonia.Node
+	Activation ActivationFunc
+}
+
+// Fwd Initializates feedforward for provided input
+//
+// batchSize - batch size. If it's >= 2 then batched multiplication/broadcasting will be applied
+func (layer *LinearLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
+	input, err := singleInput("linear", inputs...)
+	if err != nil {
+		return nil, err
+	}
+	if layer.WeightNode == nil {
+		return nil, fmt.Errorf("Linear layer's weights node is nil")
+	}
+	tOp, err := gorgonia.Transpose(layer.WeightNode)
+	if err != nil {
+		return nil, errors.Wrap(err, "Can't transpose weights of layer")
+	}
+	var layerNonActivated *gorgonia.Node
+	if batchSize < 2 {
+		layerNonActivated, err = gorgonia.Mul(input, tOp)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't multiply input and weights of layer [batch_size = 1]")
+		}
+	} else {
+		layerNonActivated, err = gorgonia.BatchedMatMul(input, tOp)
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("Can't multiply input and weights of layer [batch_size = %d]", batchSize))
+		}
+	}
+	return addBias(layerNonActivated, layer.BiasNode, batchSize)
+}
+
+// Activate Applies layer's activation function
+func (layer *LinearLayer) Activate(input *gorgonia.Node) (*gorgonia.Node, error) {
+	return applyActivation(layer.Activation, input)
+}
+
+// Learnables Returns learnable nodes
+func (layer *LinearLayer) Learnables() gorgonia.Nodes {
+	learnables := make(gorgonia.Nodes, 0, 2)
+	if layer.WeightNode != nil {
+		learnables = append(learnables, layer.WeightNode)
+	}
+	if layer.BiasNode != nil {
+		learnables = append(learnables, layer.BiasNode)
+	}
+	return learnables
+}
+
+// CloneTo Copies layer structure onto the provided graph. Learnables of the copy share underlying tensors with the source layer.
+func (layer *LinearLayer) CloneTo(g *gorgonia.ExprGraph, nameSuffix string) (Layer, error) {
+	if layer.WeightNode == nil {
+		return nil, fmt.Errorf("Linear layer has nil weight node")
+	}
+	return &LinearLayer{
+		WeightNode: cloneLearnableTo(g, layer.WeightNode, nameSuffix),
+		BiasNode:   cloneLearnableTo(g, layer.BiasNode, nameSuffix),
+		Activation: layer.Activation,
+	}, nil
+}

--- a/layer_maxpool.go
+++ b/layer_maxpool.go
@@ -1,0 +1,51 @@
+package gan_go
+
+import (
+	"github.com/pkg/errors"
+	"gorgonia.org/gorgonia"
+	"gorgonia.org/tensor"
+)
+
+// MaxpoolLayer 2D max-pooling layer. Has no learnable parameters.
+type MaxpoolLayer struct {
+	Activation ActivationFunc
+
+	KernelHeight int
+	KernelWidth  int
+	Padding      []int
+	Stride       []int
+}
+
+// Fwd Initializates feedforward for provided input
+func (layer *MaxpoolLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
+	input, err := singleInput("maxpool", inputs...)
+	if err != nil {
+		return nil, err
+	}
+	layerNonActivated, err := gorgonia.MaxPool2D(input, tensor.Shape{layer.KernelHeight, layer.KernelWidth}, layer.Padding, layer.Stride)
+	if err != nil {
+		return nil, errors.Wrap(err, "Can't maxpool[2D] input by kernel of layer")
+	}
+	return layerNonActivated, nil
+}
+
+// Activate Applies layer's activation function
+func (layer *MaxpoolLayer) Activate(input *gorgonia.Node) (*gorgonia.Node, error) {
+	return applyActivation(layer.Activation, input)
+}
+
+// Learnables Returns learnable nodes. Maxpool layer has no learnables.
+func (layer *MaxpoolLayer) Learnables() gorgonia.Nodes {
+	return gorgonia.Nodes{}
+}
+
+// CloneTo Copies layer structure onto the provided graph
+func (layer *MaxpoolLayer) CloneTo(g *gorgonia.ExprGraph, nameSuffix string) (Layer, error) {
+	return &MaxpoolLayer{
+		Activation:   layer.Activation,
+		KernelHeight: layer.KernelHeight,
+		KernelWidth:  layer.KernelWidth,
+		Padding:      layer.Padding,
+		Stride:       layer.Stride,
+	}, nil
+}

--- a/layer_reshape.go
+++ b/layer_reshape.go
@@ -1,0 +1,40 @@
+package gan_go
+
+import (
+	"github.com/pkg/errors"
+	"gorgonia.org/gorgonia"
+)
+
+// ReshapeLayer Reshapes input tensor to provided dimensions.
+// Has no learnable parameters and no activation.
+type ReshapeLayer struct {
+	Dims []int
+}
+
+// Fwd Initializates feedforward for provided input
+func (layer *ReshapeLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
+	input, err := singleInput("reshape", inputs...)
+	if err != nil {
+		return nil, err
+	}
+	reshaped, err := gorgonia.Reshape(input, layer.Dims)
+	if err != nil {
+		return nil, errors.Wrap(err, "Can't reshape input of layer")
+	}
+	return reshaped, nil
+}
+
+// Activate Reshape layer does not imply activation
+func (layer *ReshapeLayer) Activate(input *gorgonia.Node) (*gorgonia.Node, error) {
+	return input, nil
+}
+
+// Learnables Returns learnable nodes. Reshape layer has no learnables.
+func (layer *ReshapeLayer) Learnables() gorgonia.Nodes {
+	return gorgonia.Nodes{}
+}
+
+// CloneTo Copies layer structure onto the provided graph
+func (layer *ReshapeLayer) CloneTo(g *gorgonia.ExprGraph, nameSuffix string) (Layer, error) {
+	return &ReshapeLayer{Dims: layer.Dims}, nil
+}

--- a/network.go
+++ b/network.go
@@ -11,10 +11,9 @@ import (
 //
 // Layers - simple sequence of layers
 // out - alias to activated output of last layer
-//
 type Network struct {
 	Name   string
-	Layers []*Layer
+	Layers []Layer
 	out    *gorgonia.Node
 }
 
@@ -28,12 +27,7 @@ func (net *Network) Learnables() gorgonia.Nodes {
 	learnables := make(gorgonia.Nodes, 0, 2*len(net.Layers))
 	for _, l := range net.Layers {
 		if l != nil {
-			if l.WeightNode != nil {
-				learnables = append(learnables, l.WeightNode)
-			}
-			if l.BiasNode != nil {
-				learnables = append(learnables, l.BiasNode)
-			}
+			learnables = append(learnables, l.Learnables()...)
 		}
 	}
 	return learnables
@@ -41,12 +35,9 @@ func (net *Network) Learnables() gorgonia.Nodes {
 
 // Fwd Initializates feedforward for provided input
 //
-// inputs - Input node (or nodes)
+// inputs - Input node (or nodes). Only first layer of network can accept multiple inputs
 // batchSize - batch size. If it's >= 2 then broadcast function will be applied
-//
 func (net *Network) Fwd(batchSize int, inputs ...*gorgonia.Node) error {
-	var err error
-
 	if len(inputs) == 0 {
 		return fmt.Errorf("There are no input nodes for network")
 	}
@@ -59,54 +50,25 @@ func (net *Network) Fwd(batchSize int, inputs ...*gorgonia.Node) error {
 	if len(net.Layers) == 0 {
 		return fmt.Errorf("Network must have one layer atleast")
 	}
-	if net.Layers[0] == nil {
-		return fmt.Errorf("Network's layer #0 is nil")
-	}
 
-	// Feedforward input through first layer
-	firstLayerNonActivated, err := net.Layers[0].Fwd(batchSize, inputs...)
-	if err != nil {
-		return errors.Wrap(err, "[Network, Layer #0] Can't feedforward input before activation")
-	}
-	gorgonia.WithName(fmt.Sprintf("%s_0", networkName))(firstLayerNonActivated)
-	// Activate first layer's output
-	firstLayerActivated, err := net.Layers[0].Activation(firstLayerNonActivated)
-	if err != nil {
-		return errors.Wrap(err, "Can't apply activation function to non-activated output of Network's layer #0")
-	}
-	gorgonia.WithName(fmt.Sprintf("%s_activated_0", networkName))(firstLayerActivated)
-	net.Layers[0].outputActivatedNode = firstLayerActivated
-	lastActivatedLayer := firstLayerActivated
-
-	if len(net.Layers) == 1 {
-		net.out = lastActivatedLayer
-	}
-
-	// Feedforward input through remaining layers
-	for i := 1; i < len(net.Layers); i++ {
-		if net.Layers[i] == nil {
+	// Feedforward input through the layers
+	layerInputs := inputs
+	for i, layer := range net.Layers {
+		if layer == nil {
 			return fmt.Errorf("Network's layer #%d is nil", i)
 		}
-		if net.Layers[i].WeightNode == nil && !noWeightsAllowed(net.Layers[i].Type) {
-			return fmt.Errorf("Network's layer's #%d WeightNode is nil", i)
-		}
-		// Feedforward input through i-th layer (i != 0)
-		layerNonActivated, err := net.Layers[i].Fwd(batchSize, lastActivatedLayer)
+		layerNonActivated, err := layer.Fwd(batchSize, layerInputs...)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("[Network, Layer #%d] Can't feedforward input before activation", i))
 		}
 		gorgonia.WithName(fmt.Sprintf("%s_%d", networkName, i))(layerNonActivated)
-		// Activate i-th layer's output (i != 0)
-		layerActivated, err := net.Layers[i].Activation(layerNonActivated)
+		layerActivated, err := layer.Activate(layerNonActivated)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Can't apply activation function to non-activated output of Network's layer #%d", i))
 		}
 		gorgonia.WithName(fmt.Sprintf("%s_activated_%d", networkName, i))(layerActivated)
-		net.Layers[i].outputActivatedNode = layerActivated
-		lastActivatedLayer = layerActivated
-		if i == len(net.Layers)-1 {
-			net.out = layerActivated
-		}
+		layerInputs = gorgonia.Nodes{layerActivated}
 	}
+	net.out = layerInputs[0]
 	return nil
 }

--- a/utils.go
+++ b/utils.go
@@ -27,7 +27,6 @@ import (
 // batchSize - Simply batch size
 // n - Number of elements in each batch
 // Resulting dense will have batchSize*n elements
-//
 func NormRandDense(batchSize, n int) *tensor.Dense {
 	data := make([]float64, batchSize*n)
 	for i := range data {
@@ -41,7 +40,6 @@ func NormRandDense(batchSize, n int) *tensor.Dense {
 // batchSize - Simply batch size
 // n - Number of elements in each batch
 // Resulting dense will have batchSize*n elements
-//
 func UniformRandDense(batchSize, n int) *tensor.Dense {
 	data := make([]float64, batchSize*n)
 	for i := range data {
@@ -136,7 +134,6 @@ func PlotXY(x, y tensor.Tensor, fname string) error {
 // numSamples - how many sample generate
 // batchSize - batch size basically
 // n - number of elements in each batch (latent space size)
-//
 func GenerateNormTestSamples(vmGenerator, vmDiscriminator gorgonia.VM, inputGenerator, inputDiscriminator *gorgonia.Node, generatorOutValue gorgonia.Value, numSamples, batchSize, n int, shape tensor.Shape) (*tensor.Dense, error) {
 	var testSamplesTensor *tensor.Dense
 
@@ -194,7 +191,6 @@ func GenerateNormTestSamples(vmGenerator, vmDiscriminator gorgonia.VM, inputGene
 // numSamples - how many sample generate
 // batchSize - batch size basically
 // n - number of elements in each batch (latent space size)
-//
 func GenerateUniformTestSamples(vmGenerator, vmDiscriminator gorgonia.VM, inputGenerator, inputDiscriminator *gorgonia.Node, generatorOutValue gorgonia.Value, numSamples, batchSize, n int, shape tensor.Shape) (*tensor.Dense, error) {
 	var testSamplesTensor *tensor.Dense
 


### PR DESCRIPTION
- `Layer` is now an interface (`Fwd` / `Activate` / `Learnables` / `CloneTo`), with a separate struct per layer type (`LinearLayer`, `Conv2DLayer`, `MaxpoolLayer`, `FlattenLayer`, `ReshapeLayer`, `DropoutLayer`, `EmbeddingLayer`) - one file per layer. The type enum, the giant switch in `Fwd` and the shared `Options` grab-bag are gone: each layer holds only its own fields.
- `NewGAN` copies the discriminator via `CloneTo(...)` instead of poking struct fields. The weight-sharing trick (copies bound to the same tensors via `WithValue`, so in-place solver updates propagate between graphs) is preserved and documented.
- All examples migrated to the new typed literals.


No behavior changes + layer dispatch happens only at graph construction time - runtime performance is unaffected.


**Breaking change** - layer definitions must be migrated:

```go
// before
&gan.Layer{
        WeightNode: w,
        BiasNode: b,
        Type: gan.LayerLinear,
        Activation: gan.Rectify
}
// after
&gan.LinearLayer{
	WeightNode: w,
	BiasNode:   b,
	Activation: gan.Rectify,
}
```
