### PR TITLE
Add LSTM layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Current examples folder contains limited set of layer types:
 - [x] Embedding
 - [x] LSTM
 
+_Note #3_: *some layer types (e.g. LSTM) and examples (train_cnn, train_embedding, train_lstm) are not related to GAN topic itself. They just show how to build neural networks of other kinds with the same set of abstractions*
+
 ## Why
 Just want to do that in Golang ecosystem.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Current examples folder contains limited set of layer types:
 - [x] Reshape
 - [x] Dropout
 - [x] Embedding
-- [ ] LSTM
+- [x] LSTM
 
 ## Why
 Just want to do that in Golang ecosystem.

--- a/cmd/examples/train_lstm/README.md
+++ b/cmd/examples/train_lstm/README.md
@@ -1,0 +1,57 @@
+# Example of how to use LSTM layer
+
+This example is not about GAN itself: a small word level language model is trained to continue sentences of a tiny corpus.
+
+Corpus:
+```
+the quick brown fox jumps over the lazy dog
+the little cat sleeps under the warm sun
+a small bird sings in the green garden
+the old dog walks slowly through the park
+a young fox hides behind the tall tree
+```
+
+Network structure:
+```
+input(4 word indices) => embedding(voc=31, dims=16) => lstm(inputs=16, hidden=32) => linear(31, 32) + softmax
+```
+
+Every training window is a sequence of 4 words and the target is the same sequence shifted by one word, so the network learns to predict the next word for every position of the window.
+
+Training details: cross entropy loss, Adam solver, learning rate is 0.01, 200 epochs.
+
+After training the network is asked to continue every sentence of the corpus given its first 4 words: the most probable word at the last position of the window is appended and the window slides forward.
+
+Simply execute:
+```shell
+go run main.go
+```
+
+Final output (may vary due the nature of rand() calls):
+```shell
+Vocabulary size: 31
+Number of training windows: 21
+Epoch 0:
+	Loss: 0.11104210591411041
+Epoch 40:
+	Loss: 0.00882740368445253
+Epoch 80:
+	Loss: 0.00631720821663664
+Epoch 120:
+	Loss: 2.4566094610844825e-05
+Epoch 160:
+	Loss: 0.011674595601638622
+Epoch 200:
+	Loss: 9.005437827311226e-06
+Start testing generator after final epoch
+	Seed: the quick brown fox
+	Continued: the quick brown fox jumps over the lazy dog [OK]
+	Seed: the little cat sleeps
+	Continued: the little cat sleeps under the warm sun [OK]
+	Seed: a small bird sings
+	Continued: a small bird sings in the green garden [OK]
+	Seed: the old dog walks
+	Continued: the old dog walks slowly through the park [OK]
+	Seed: a young fox hides
+	Continued: a young fox hides behind the tall tree [OK]
+```

--- a/cmd/examples/train_lstm/main.go
+++ b/cmd/examples/train_lstm/main.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"strings"
+
+	gan "github.com/LdDl/gan-go"
+	"gorgonia.org/gorgonia"
+	"gorgonia.org/tensor"
+)
+
+var (
+	corpus = []string{
+		"the quick brown fox jumps over the lazy dog",
+		"the little cat sleeps under the warm sun",
+		"a small bird sings in the green garden",
+		"the old dog walks slowly through the park",
+		"a young fox hides behind the tall tree",
+	}
+	sequenceLength = 4
+	embeddingSize  = 16
+	hiddenSize     = 32
+	learningRate   = 0.01
+	numOfEpochs    = 201
+	evalPrint      = 40
+)
+
+type window struct {
+	Input  []int
+	Target []float64
+}
+
+func main() {
+	rand.Seed(1337)
+
+	/* Prepare dataset */
+	vocab, wordToIndex := buildVocabulary(corpus)
+	vocabSize := len(vocab)
+	windows := buildWindows(corpus, wordToIndex, sequenceLength, vocabSize)
+	fmt.Printf("Vocabulary size: %d\n", vocabSize)
+	fmt.Printf("Number of training windows: %d\n", len(windows))
+
+	/* Define Gorgonia's graph */
+	netGraph := gorgonia.NewGraph()
+
+	/* Define neural network */
+	lstmNet := defineNet(netGraph, vocabSize)
+
+	/* Prepare tensor for input values */
+	inputNet := gorgonia.NewTensor(netGraph, gorgonia.Int, 1, gorgonia.WithShape(sequenceLength), gorgonia.WithName("lstm_train_input"))
+	err := lstmNet.Fwd(1, inputNet)
+	if err != nil {
+		panic(err)
+	}
+
+	/* Prepare tensor for target values */
+	targetNet := gorgonia.NewTensor(netGraph, gorgonia.Float64, 2, gorgonia.WithShape(sequenceLength, vocabSize), gorgonia.WithName("lstm_train_target"))
+
+	/* Prepare variable for storing neural network's output */
+	var netOut gorgonia.Value
+	gorgonia.Read(lstmNet.Out(), &netOut)
+
+	/* Prepare cost node */
+	cost, err := gan.CrossEntropyLoss(lstmNet.Out(), targetNet)
+	if err != nil {
+		panic(err)
+	}
+	gorgonia.WithName("lstm_loss")(cost)
+
+	/* Define gradients */
+	_, err = gorgonia.Grad(cost, lstmNet.Learnables()...)
+	if err != nil {
+		panic(err)
+	}
+
+	/* Prepare variable for storing neural network's cost */
+	var costOut gorgonia.Value
+	gorgonia.Read(cost, &costOut)
+
+	/* Define tape machine */
+	tm := gorgonia.NewTapeMachine(netGraph, gorgonia.BindDualValues(lstmNet.Learnables()...))
+	defer tm.Close()
+
+	/* Initialize solver for evaluation graph */
+	solver := gorgonia.NewAdamSolver(gorgonia.WithBatchSize(1), gorgonia.WithLearnRate(learningRate))
+
+	/* Training process */
+	for e := 0; e < numOfEpochs; e++ {
+		for i := range windows {
+			in := tensor.New(tensor.WithShape(sequenceLength), tensor.WithBacking(windows[i].Input))
+			err = gorgonia.Let(inputNet, in)
+			if err != nil {
+				panic(err)
+			}
+			desired := tensor.New(tensor.WithShape(sequenceLength, vocabSize), tensor.WithBacking(windows[i].Target))
+			err = gorgonia.Let(targetNet, desired)
+			if err != nil {
+				panic(err)
+			}
+			/* Run training step */
+			err = tm.RunAll()
+			if err != nil {
+				panic(err)
+			}
+			err = solver.Step(gorgonia.NodesToValueGrads(lstmNet.Learnables()))
+			if err != nil {
+				panic(err)
+			}
+			tm.Reset()
+		}
+		// Shuffle training windows
+		rand.Shuffle(len(windows), func(i, j int) { windows[i], windows[j] = windows[j], windows[i] })
+		if e%evalPrint == 0 {
+			fmt.Printf("Epoch %d:\n", e)
+			fmt.Printf("\tLoss: %v\n", costOut)
+		}
+	}
+
+	/* Test: continue every sentence of the corpus from its first words */
+	fmt.Println("Start testing generator after final epoch")
+	dummyTarget := tensor.New(tensor.WithShape(sequenceLength, vocabSize), tensor.WithBacking(make([]float64, sequenceLength*vocabSize)))
+	for _, sentence := range corpus {
+		words := strings.Fields(sentence)
+		seed := make([]int, sequenceLength)
+		for i := 0; i < sequenceLength; i++ {
+			seed[i] = wordToIndex[words[i]]
+		}
+		generated := make([]string, 0, len(words))
+		generated = append(generated, words[:sequenceLength]...)
+		for len(generated) < len(words) {
+			in := tensor.New(tensor.WithShape(sequenceLength), tensor.WithBacking(append([]int{}, seed...)))
+			err = gorgonia.Let(inputNet, in)
+			if err != nil {
+				panic(err)
+			}
+			err = gorgonia.Let(targetNet, dummyTarget)
+			if err != nil {
+				panic(err)
+			}
+			err = tm.RunAll()
+			if err != nil {
+				panic(err)
+			}
+			probabilities := netOut.Data().([]float64)
+			tm.Reset()
+			// Next word is the most probable prediction at the last position of the window
+			nextWord := argmax(probabilities[(sequenceLength-1)*vocabSize : sequenceLength*vocabSize])
+			generated = append(generated, vocab[nextWord])
+			seed = append(seed[1:], nextWord)
+		}
+		matched := "OK"
+		if strings.Join(generated, " ") != sentence {
+			matched = "MISMATCH"
+		}
+		fmt.Printf("\tSeed: %v\n", strings.Join(words[:sequenceLength], " "))
+		fmt.Printf("\tContinued: %v [%s]\n", strings.Join(generated, " "), matched)
+	}
+}
+
+func defineNet(g *gorgonia.ExprGraph, vocabSize int) *gan.DiscriminatorNet {
+	embedding_w0 := gorgonia.NewTensor(g, gorgonia.Float64, 2, gorgonia.WithShape(vocabSize, embeddingSize), gorgonia.WithName("lstm_train_embedding_w0"), gorgonia.WithInit(gorgonia.GlorotN(1.0)))
+
+	lstm_input_w0 := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(embeddingSize, 4*hiddenSize), gorgonia.WithName("lstm_train_input_w0"), gorgonia.WithInit(gorgonia.GlorotN(1.0)))
+	lstm_hidden_w0 := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(hiddenSize, 4*hiddenSize), gorgonia.WithName("lstm_train_hidden_w0"), gorgonia.WithInit(gorgonia.GlorotN(1.0)))
+	lstm_b0 := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(1, 4*hiddenSize), gorgonia.WithName("lstm_train_b0"), gorgonia.WithInit(gorgonia.Zeroes()))
+
+	linear_w0 := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(vocabSize, hiddenSize), gorgonia.WithName("lstm_train_linear_w0"), gorgonia.WithInit(gorgonia.GlorotN(1.0)))
+
+	net := gan.Discriminator(
+		&gan.EmbeddingLayer{
+			WeightNode:    embedding_w0,
+			EmbeddingSize: embeddingSize,
+		},
+		&gan.LSTMLayer{
+			InputWeightNode:  lstm_input_w0,
+			HiddenWeightNode: lstm_hidden_w0,
+			BiasNode:         lstm_b0,
+			HiddenSize:       hiddenSize,
+		},
+		&gan.LinearLayer{
+			WeightNode: linear_w0,
+			Activation: gan.WithActivationOptions(gan.Softmax, gan.Options{Axis: []int{1}}),
+		},
+	)
+	return net
+}
+
+// buildVocabulary Collects sorted unique words of the corpus
+func buildVocabulary(sentences []string) ([]string, map[string]int) {
+	unique := make(map[string]bool)
+	for _, sentence := range sentences {
+		for _, word := range strings.Fields(sentence) {
+			unique[word] = true
+		}
+	}
+	vocab := make([]string, 0, len(unique))
+	for word := range unique {
+		vocab = append(vocab, word)
+	}
+	sort.Strings(vocab)
+	wordToIndex := make(map[string]int, len(vocab))
+	for i, word := range vocab {
+		wordToIndex[word] = i
+	}
+	return vocab, wordToIndex
+}
+
+// buildWindows Prepares sliding windows: for tokens t[i]...t[i+n-1] target is one-hot encoded t[i+1]...t[i+n]
+func buildWindows(sentences []string, wordToIndex map[string]int, n, vocabSize int) []window {
+	windows := []window{}
+	for _, sentence := range sentences {
+		words := strings.Fields(sentence)
+		tokens := make([]int, len(words))
+		for i, word := range words {
+			tokens[i] = wordToIndex[word]
+		}
+		for i := 0; i+n < len(tokens); i++ {
+			target := make([]float64, n*vocabSize)
+			for j := 0; j < n; j++ {
+				target[j*vocabSize+tokens[i+1+j]] = 1.0
+			}
+			windows = append(windows, window{
+				Input:  tokens[i : i+n],
+				Target: target,
+			})
+		}
+	}
+	return windows
+}
+
+func argmax(values []float64) int {
+	best := 0
+	for i := range values {
+		if values[i] > values[best] {
+			best = i
+		}
+	}
+	return best
+}

--- a/gan.go
+++ b/gan.go
@@ -18,7 +18,7 @@ import (
 // is defined on its own graph (where it is trained) and its structure is copied into the GAN's graph
 // via CloneTo(...) method of Layer interface.
 // Each copied learnable node is created with gorgonia.WithValue(originalNode.Value()) which binds the SAME
-// underlying tensor (same backing memory) to both nodes — it is NOT a deep copy.
+// underlying tensor (same backing memory) to both nodes. It is NOT a deep copy.
 // Since Gorgonia's solvers update weights in-place, every training step of the Discriminator
 // on its own graph is immediately "visible" to the copied nodes in the GAN's graph.
 // So there is no need to manually sync weights between the two graphs.

--- a/layer_lstm.go
+++ b/layer_lstm.go
@@ -1,0 +1,259 @@
+package gan_go
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"gorgonia.org/gorgonia"
+	"gorgonia.org/tensor"
+)
+
+// LSTMLayer Long short-term memory layer.
+//
+// All four gates (input, forget, cell candidate, output) are packed into single weight matrices,
+// so for hidden size H:
+//
+//	InputWeightNode holds W of shape [input_features, 4*H]
+//	HiddenWeightNode holds U of shape [H, 4*H]
+//	BiasNode (optional) holds b of shape [1, 4*H]
+//
+// For time step t gates are computed as slices of (x_t * W + h_prev * U + b), then:
+//
+//	c_t = sigmoid(f) ⊙ c_prev + sigmoid(i) ⊙ tanh(g)
+//	h_t = sigmoid(o) ⊙ tanh(c_t)
+//
+// where sigmoid could be replaced via RecurrentActivation and tanh via Activation.
+//
+// Input must be a tensor of shape [sequence, input_features] or [sequence, batch, input_features].
+// Output is a tensor of hidden states for every time step: [sequence, H] or [sequence, batch, H] respectively.
+//
+// Initial hidden state and initial cell state are zero-valued nodes created automatically.
+// Custom ones could be provided either via InitialHiddenNode/InitialCellNode fields
+// or as second and third input nodes of Fwd() call. Expected shape is [batch, H].
+type LSTMLayer struct {
+	InputWeightNode  *gorgonia.Node
+	HiddenWeightNode *gorgonia.Node
+	BiasNode         *gorgonia.Node
+
+	InitialHiddenNode *gorgonia.Node
+	InitialCellNode   *gorgonia.Node
+
+	HiddenSize int
+	/* Cell candidate and cell output activation. Should be Tanh most of times (used if nil) */
+	Activation ActivationFunc
+	/* Gates activation. Should be Sigmoid most of times (used if nil) */
+	RecurrentActivation ActivationFunc
+
+	finalHiddenNode *gorgonia.Node
+	finalCellNode   *gorgonia.Node
+}
+
+// FinalHidden Returns reference to hidden state node of the last time step. It is set by Fwd() call
+func (layer *LSTMLayer) FinalHidden() *gorgonia.Node {
+	return layer.finalHiddenNode
+}
+
+// FinalCell Returns reference to cell state node of the last time step. It is set by Fwd() call
+func (layer *LSTMLayer) FinalCell() *gorgonia.Node {
+	return layer.finalCellNode
+}
+
+// Fwd Initializates feedforward for provided input
+//
+// inputs - either single input node or (input, initial hidden state, initial cell state) triple
+// batchSize - not used by this layer type since batch size is derived from the input shape
+func (layer *LSTMLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
+	var input, hiddenState, cellState *gorgonia.Node
+	switch len(inputs) {
+	case 1:
+		input = inputs[0]
+		hiddenState = layer.InitialHiddenNode
+		cellState = layer.InitialCellNode
+	case 3:
+		input = inputs[0]
+		hiddenState = inputs[1]
+		cellState = inputs[2]
+	default:
+		return nil, fmt.Errorf("Layer of type 'lstm' can handle either 1 or 3 input nodes, got %d", len(inputs))
+	}
+	if layer.InputWeightNode == nil {
+		return nil, fmt.Errorf("LSTM layer's input weights node is nil")
+	}
+	if layer.HiddenWeightNode == nil {
+		return nil, fmt.Errorf("LSTM layer's hidden weights node is nil")
+	}
+	if layer.HiddenSize < 1 {
+		return nil, fmt.Errorf("LSTM layer's hidden size should be positive, got %d", layer.HiddenSize)
+	}
+	hiddenSize := layer.HiddenSize
+	if got := layer.InputWeightNode.Shape()[1]; got != 4*hiddenSize {
+		return nil, fmt.Errorf("LSTM layer's input weights node should have shape [input_features, %d], got %v", 4*hiddenSize, layer.InputWeightNode.Shape())
+	}
+	if got := layer.HiddenWeightNode.Shape(); got[0] != hiddenSize || got[1] != 4*hiddenSize {
+		return nil, fmt.Errorf("LSTM layer's hidden weights node should have shape [%d, %d], got %v", hiddenSize, 4*hiddenSize, got)
+	}
+	cellActivation := layer.Activation
+	if cellActivation == nil {
+		cellActivation = Tanh
+	}
+	gatesActivation := layer.RecurrentActivation
+	if gatesActivation == nil {
+		gatesActivation = Sigmoid
+	}
+
+	// Single code path for both [sequence, features] and [sequence, batch, features] inputs
+	squeezeOutput := false
+	if input.Dims() == 2 {
+		squeezeOutput = true
+		reshaped, err := gorgonia.Reshape(input, tensor.Shape{input.Shape()[0], 1, input.Shape()[1]})
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't add batch dimension to LSTM layer's input")
+		}
+		input = reshaped
+	}
+	if input.Dims() != 3 {
+		return nil, fmt.Errorf("LSTM layer's input should have shape [sequence, input_features] or [sequence, batch, input_features], got %v", input.Shape())
+	}
+	sequenceLength := input.Shape()[0]
+	batch := input.Shape()[1]
+
+	// Zero-valued initial states unless custom ones are provided.
+	// Names must be unique in scope of graph: Gorgonia hashes input nodes by type, shape and name only
+	if hiddenState == nil {
+		hiddenState = gorgonia.NewMatrix(input.Graph(), input.Dtype(), gorgonia.WithShape(batch, hiddenSize), gorgonia.WithInit(gorgonia.Zeroes()), gorgonia.WithName(fmt.Sprintf("lstm_%d_initial_hidden", input.ID())))
+	}
+	if cellState == nil {
+		cellState = gorgonia.NewMatrix(input.Graph(), input.Dtype(), gorgonia.WithShape(batch, hiddenSize), gorgonia.WithInit(gorgonia.Zeroes()), gorgonia.WithName(fmt.Sprintf("lstm_%d_initial_cell", input.ID())))
+	}
+
+	outputs := make([]*gorgonia.Node, sequenceLength)
+	for t := 0; t < sequenceLength; t++ {
+		// x_t of shape [batch, input_features]
+		xt, err := gorgonia.Slice(input, gorgonia.S(t), nil, nil)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Can't slice time step %d of LSTM layer's input of shape %v", t, input.Shape())
+		}
+		inputProjection, err := gorgonia.Mul(xt, layer.InputWeightNode)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't multiply time step input and input weights of LSTM layer")
+		}
+		hiddenProjection, err := gorgonia.Mul(hiddenState, layer.HiddenWeightNode)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't multiply previous hidden state and hidden weights of LSTM layer")
+		}
+		gates, err := gorgonia.Add(inputProjection, hiddenProjection)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't sum input and hidden projections of LSTM layer")
+		}
+		gates, err = addBias(gates, layer.BiasNode, batch)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't add bias to gates of LSTM layer")
+		}
+		// Gates are slices of columns: input, forget, cell candidate, output
+		inputGate, err := sliceGate(gates, 0, hiddenSize, gatesActivation)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't extract input gate of LSTM layer")
+		}
+		forgetGate, err := sliceGate(gates, 1, hiddenSize, gatesActivation)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't extract forget gate of LSTM layer")
+		}
+		cellCandidate, err := sliceGate(gates, 2, hiddenSize, cellActivation)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't extract cell candidate of LSTM layer")
+		}
+		outputGate, err := sliceGate(gates, 3, hiddenSize, gatesActivation)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't extract output gate of LSTM layer")
+		}
+		// c_t = forget ⊙ c_prev + input ⊙ candidate
+		preservedCell, err := gorgonia.HadamardProd(forgetGate, cellState)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't apply forget gate to previous cell state of LSTM layer")
+		}
+		incomingCell, err := gorgonia.HadamardProd(inputGate, cellCandidate)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't apply input gate to cell candidate of LSTM layer")
+		}
+		cellState, err = gorgonia.Add(preservedCell, incomingCell)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't update cell state of LSTM layer")
+		}
+		// h_t = output ⊙ activation(c_t)
+		cellStateActivated, err := cellActivation(cellState)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't apply activation function to cell state of LSTM layer")
+		}
+		hiddenState, err = gorgonia.HadamardProd(outputGate, cellStateActivated)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't update hidden state of LSTM layer")
+		}
+		outputs[t], err = gorgonia.Reshape(hiddenState, tensor.Shape{1, batch, hiddenSize})
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't add time dimension to hidden state of LSTM layer")
+		}
+	}
+	layer.finalHiddenNode = hiddenState
+	layer.finalCellNode = cellState
+
+	layerNonActivated, err := gorgonia.Concat(0, outputs...)
+	if err != nil {
+		return nil, errors.Wrap(err, "Can't concatenate hidden states of LSTM layer")
+	}
+	if squeezeOutput {
+		layerNonActivated, err = gorgonia.Reshape(layerNonActivated, tensor.Shape{sequenceLength, hiddenSize})
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't squeeze batch dimension of LSTM layer's output")
+		}
+	}
+	return layerNonActivated, nil
+}
+
+// sliceGate Extracts single gate (columns [idx*hiddenSize; (idx+1)*hiddenSize)) and applies activation function to it
+func sliceGate(gates *gorgonia.Node, idx, hiddenSize int, activation ActivationFunc) (*gorgonia.Node, error) {
+	gate, err := gorgonia.Slice(gates, nil, gorgonia.S(idx*hiddenSize, (idx+1)*hiddenSize))
+	if err != nil {
+		return nil, errors.Wrap(err, "Can't slice gate")
+	}
+	return activation(gate)
+}
+
+// Activate LSTM layer does not imply activation of output: activation functions are applied inside of the cell
+func (layer *LSTMLayer) Activate(input *gorgonia.Node) (*gorgonia.Node, error) {
+	return input, nil
+}
+
+// Learnables Returns learnable nodes
+func (layer *LSTMLayer) Learnables() gorgonia.Nodes {
+	learnables := make(gorgonia.Nodes, 0, 3)
+	if layer.InputWeightNode != nil {
+		learnables = append(learnables, layer.InputWeightNode)
+	}
+	if layer.HiddenWeightNode != nil {
+		learnables = append(learnables, layer.HiddenWeightNode)
+	}
+	if layer.BiasNode != nil {
+		learnables = append(learnables, layer.BiasNode)
+	}
+	return learnables
+}
+
+// CloneTo Copies layer structure onto the provided graph. Learnables of the copy share underlying tensors with the source layer
+func (layer *LSTMLayer) CloneTo(g *gorgonia.ExprGraph, nameSuffix string) (Layer, error) {
+	if layer.InputWeightNode == nil {
+		return nil, fmt.Errorf("LSTM layer has nil input weights node")
+	}
+	if layer.HiddenWeightNode == nil {
+		return nil, fmt.Errorf("LSTM layer has nil hidden weights node")
+	}
+	return &LSTMLayer{
+		InputWeightNode:     cloneLearnableTo(g, layer.InputWeightNode, nameSuffix),
+		HiddenWeightNode:    cloneLearnableTo(g, layer.HiddenWeightNode, nameSuffix),
+		BiasNode:            cloneLearnableTo(g, layer.BiasNode, nameSuffix),
+		InitialHiddenNode:   cloneLearnableTo(g, layer.InitialHiddenNode, nameSuffix),
+		InitialCellNode:     cloneLearnableTo(g, layer.InitialCellNode, nameSuffix),
+		HiddenSize:          layer.HiddenSize,
+		Activation:          layer.Activation,
+		RecurrentActivation: layer.RecurrentActivation,
+	}, nil
+}

--- a/loss.go
+++ b/loss.go
@@ -166,7 +166,7 @@ func L1Loss(a, b *gorgonia.Node, reduction ...LossReduction) (*gorgonia.Node, er
 // Default reduction is 'mean'
 func HuberLoss(a, b *gorgonia.Node, delta interface{}, reduction ...LossReduction) (*gorgonia.Node, error) {
 	// Important: value (input) nodes MUST be named uniquely here.
-	// Gorgonia hashes input nodes by (type + shape + name) only — the value is NOT part of the hash.
+	// Gorgonia hashes input nodes by (type + shape + name) only. The value is NOT part of the hash.
 	// Two unnamed scalars of the same dtype would be deduplicated into a single node by the graph,
 	// silently replacing e.g. the constant 1.0 with the value of delta.
 	deltaScalar := gorgonia.NewScalar(a.Graph(), a.Dtype(), gorgonia.WithValue(delta), gorgonia.WithName(fmt.Sprintf("huber_delta_%d_%d", a.ID(), b.ID())))


### PR DESCRIPTION
- New `LSTMLayer` implementing the `Layer` interface. All four gates are packed into single weight matrices: `InputWeightNode` [features, 4H], `HiddenWeightNode` [H, 4H] and optional `BiasNode` [1, 4H]. Cell and gate activations are configurable (Tanh/Sigmoid by default).
- Input is a sequence [seq, features] or [seq, batch, features], output holds hidden states of every time step. Zero initial states are created automatically, custom ones can be passed via fields or as extra inputs of `Fwd`. Final states are exposed via `FinalHidden()`/`FinalCell()`.
- `CloneTo` support, so LSTM can be used in the discriminator part of GAN as any other layer.
- New example `cmd/examples/train_lstm`: a word level language model (embedding, LSTM, linear with softmax) trained on a tiny corpus. After training it continues every sentence of the corpus from its first 4 words without mistakes.

Forward pass is verified against a hand computed reference (matches to 1e-12 per time step), gradients and solver steps through the unrolled recurrence work.
