### PR TITLE
Add RNN layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ Current examples folder contains limited set of layer types:
 - [x] Dropout
 - [x] Embedding
 - [x] LSTM
+- [x] RNN
 
-_Note #3_: *some layer types (e.g. LSTM) and examples (train_cnn, train_embedding, train_lstm) are not related to GAN topic itself. They just show how to build neural networks of other kinds with the same set of abstractions*
+_Note #3_: *some layer types (e.g. LSTM, RNN) and examples (train_cnn, train_embedding, train_lstm, train_rnn) are not related to GAN topic itself. They just show how to build neural networks of other kinds with the same set of abstractions*
 
 ## Why
 Just want to do that in Golang ecosystem.
@@ -122,7 +123,7 @@ Current stage of TODO list for future releases:
 - [x] Simple LSTM
     - [x] Proper layer type
     - [x] Examples
-- [ ] RNN
+- [x] RNN
 - [ ] GRU
 - [x] Embedding    
 

--- a/cmd/examples/train_rnn/README.md
+++ b/cmd/examples/train_rnn/README.md
@@ -1,0 +1,57 @@
+# Example of how to use RNN layer
+
+This example is not about GAN itself: a small word level language model is trained to continue sentences of a tiny corpus. It is the same task as in the train_lstm example, but the recurrent layer is a vanilla RNN.
+
+Corpus:
+```
+the quick brown fox jumps over the lazy dog
+the little cat sleeps under the warm sun
+a small bird sings in the green garden
+the old dog walks slowly through the park
+a young fox hides behind the tall tree
+```
+
+Network structure:
+```
+input(4 word indices) => embedding(voc=31, dims=16) => rnn(inputs=16, hidden=32) => linear(31, 32) + softmax
+```
+
+Every training window is a sequence of 4 words and the target is the same sequence shifted by one word, so the network learns to predict the next word for every position of the window.
+
+Training details: cross entropy loss, Adam solver, learning rate is 0.01, 200 epochs.
+
+After training the network is asked to continue every sentence of the corpus given its first 4 words: the most probable word at the last position of the window is appended and the window slides forward.
+
+Simply execute:
+```shell
+go run main.go
+```
+
+Final output (may vary due the nature of rand() calls):
+```shell
+Vocabulary size: 31
+Number of training windows: 21
+Epoch 0:
+	Loss: 0.11465794416131833
+Epoch 40:
+	Loss: 0.009585576220268904
+Epoch 80:
+	Loss: 0.006618245342070405
+Epoch 120:
+	Loss: 2.3746289899661273e-05
+Epoch 160:
+	Loss: 0.012220956174697525
+Epoch 200:
+	Loss: 6.651443664670986e-05
+Start testing generator after final epoch
+	Seed: the quick brown fox
+	Continued: the quick brown fox jumps over the lazy dog [OK]
+	Seed: the little cat sleeps
+	Continued: the little cat sleeps under the warm sun [OK]
+	Seed: a small bird sings
+	Continued: a small bird sings in the green garden [OK]
+	Seed: the old dog walks
+	Continued: the old dog walks slowly through the park [OK]
+	Seed: a young fox hides
+	Continued: a young fox hides behind the tall tree [OK]
+```

--- a/cmd/examples/train_rnn/main.go
+++ b/cmd/examples/train_rnn/main.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"strings"
+
+	gan "github.com/LdDl/gan-go"
+	"gorgonia.org/gorgonia"
+	"gorgonia.org/tensor"
+)
+
+var (
+	corpus = []string{
+		"the quick brown fox jumps over the lazy dog",
+		"the little cat sleeps under the warm sun",
+		"a small bird sings in the green garden",
+		"the old dog walks slowly through the park",
+		"a young fox hides behind the tall tree",
+	}
+	sequenceLength = 4
+	embeddingSize  = 16
+	hiddenSize     = 32
+	learningRate   = 0.01
+	numOfEpochs    = 201
+	evalPrint      = 40
+)
+
+type window struct {
+	Input  []int
+	Target []float64
+}
+
+func main() {
+	rand.Seed(1337)
+
+	/* Prepare dataset */
+	vocab, wordToIndex := buildVocabulary(corpus)
+	vocabSize := len(vocab)
+	windows := buildWindows(corpus, wordToIndex, sequenceLength, vocabSize)
+	fmt.Printf("Vocabulary size: %d\n", vocabSize)
+	fmt.Printf("Number of training windows: %d\n", len(windows))
+
+	/* Define Gorgonia's graph */
+	netGraph := gorgonia.NewGraph()
+
+	/* Define neural network */
+	rnnNet := defineNet(netGraph, vocabSize)
+
+	/* Prepare tensor for input values */
+	inputNet := gorgonia.NewTensor(netGraph, gorgonia.Int, 1, gorgonia.WithShape(sequenceLength), gorgonia.WithName("rnn_train_input"))
+	err := rnnNet.Fwd(1, inputNet)
+	if err != nil {
+		panic(err)
+	}
+
+	/* Prepare tensor for target values */
+	targetNet := gorgonia.NewTensor(netGraph, gorgonia.Float64, 2, gorgonia.WithShape(sequenceLength, vocabSize), gorgonia.WithName("rnn_train_target"))
+
+	/* Prepare variable for storing neural network's output */
+	var netOut gorgonia.Value
+	gorgonia.Read(rnnNet.Out(), &netOut)
+
+	/* Prepare cost node */
+	cost, err := gan.CrossEntropyLoss(rnnNet.Out(), targetNet)
+	if err != nil {
+		panic(err)
+	}
+	gorgonia.WithName("rnn_loss")(cost)
+
+	/* Define gradients */
+	_, err = gorgonia.Grad(cost, rnnNet.Learnables()...)
+	if err != nil {
+		panic(err)
+	}
+
+	/* Prepare variable for storing neural network's cost */
+	var costOut gorgonia.Value
+	gorgonia.Read(cost, &costOut)
+
+	/* Define tape machine */
+	tm := gorgonia.NewTapeMachine(netGraph, gorgonia.BindDualValues(rnnNet.Learnables()...))
+	defer tm.Close()
+
+	/* Initialize solver for evaluation graph */
+	solver := gorgonia.NewAdamSolver(gorgonia.WithBatchSize(1), gorgonia.WithLearnRate(learningRate))
+
+	/* Training process */
+	for e := 0; e < numOfEpochs; e++ {
+		for i := range windows {
+			in := tensor.New(tensor.WithShape(sequenceLength), tensor.WithBacking(windows[i].Input))
+			err = gorgonia.Let(inputNet, in)
+			if err != nil {
+				panic(err)
+			}
+			desired := tensor.New(tensor.WithShape(sequenceLength, vocabSize), tensor.WithBacking(windows[i].Target))
+			err = gorgonia.Let(targetNet, desired)
+			if err != nil {
+				panic(err)
+			}
+			/* Run training step */
+			err = tm.RunAll()
+			if err != nil {
+				panic(err)
+			}
+			err = solver.Step(gorgonia.NodesToValueGrads(rnnNet.Learnables()))
+			if err != nil {
+				panic(err)
+			}
+			tm.Reset()
+		}
+		// Shuffle training windows
+		rand.Shuffle(len(windows), func(i, j int) { windows[i], windows[j] = windows[j], windows[i] })
+		if e%evalPrint == 0 {
+			fmt.Printf("Epoch %d:\n", e)
+			fmt.Printf("\tLoss: %v\n", costOut)
+		}
+	}
+
+	/* Test: continue every sentence of the corpus from its first words */
+	fmt.Println("Start testing generator after final epoch")
+	dummyTarget := tensor.New(tensor.WithShape(sequenceLength, vocabSize), tensor.WithBacking(make([]float64, sequenceLength*vocabSize)))
+	for _, sentence := range corpus {
+		words := strings.Fields(sentence)
+		seed := make([]int, sequenceLength)
+		for i := 0; i < sequenceLength; i++ {
+			seed[i] = wordToIndex[words[i]]
+		}
+		generated := make([]string, 0, len(words))
+		generated = append(generated, words[:sequenceLength]...)
+		for len(generated) < len(words) {
+			in := tensor.New(tensor.WithShape(sequenceLength), tensor.WithBacking(append([]int{}, seed...)))
+			err = gorgonia.Let(inputNet, in)
+			if err != nil {
+				panic(err)
+			}
+			err = gorgonia.Let(targetNet, dummyTarget)
+			if err != nil {
+				panic(err)
+			}
+			err = tm.RunAll()
+			if err != nil {
+				panic(err)
+			}
+			probabilities := netOut.Data().([]float64)
+			tm.Reset()
+			// Next word is the most probable prediction at the last position of the window
+			nextWord := argmax(probabilities[(sequenceLength-1)*vocabSize : sequenceLength*vocabSize])
+			generated = append(generated, vocab[nextWord])
+			seed = append(seed[1:], nextWord)
+		}
+		matched := "OK"
+		if strings.Join(generated, " ") != sentence {
+			matched = "MISMATCH"
+		}
+		fmt.Printf("\tSeed: %v\n", strings.Join(words[:sequenceLength], " "))
+		fmt.Printf("\tContinued: %v [%s]\n", strings.Join(generated, " "), matched)
+	}
+}
+
+func defineNet(g *gorgonia.ExprGraph, vocabSize int) *gan.DiscriminatorNet {
+	embedding_w0 := gorgonia.NewTensor(g, gorgonia.Float64, 2, gorgonia.WithShape(vocabSize, embeddingSize), gorgonia.WithName("rnn_train_embedding_w0"), gorgonia.WithInit(gorgonia.GlorotN(1.0)))
+
+	rnn_input_w0 := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(embeddingSize, hiddenSize), gorgonia.WithName("rnn_train_input_w0"), gorgonia.WithInit(gorgonia.GlorotN(1.0)))
+	rnn_hidden_w0 := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(hiddenSize, hiddenSize), gorgonia.WithName("rnn_train_hidden_w0"), gorgonia.WithInit(gorgonia.GlorotN(1.0)))
+	rnn_b0 := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(1, hiddenSize), gorgonia.WithName("rnn_train_b0"), gorgonia.WithInit(gorgonia.Zeroes()))
+
+	linear_w0 := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(vocabSize, hiddenSize), gorgonia.WithName("rnn_train_linear_w0"), gorgonia.WithInit(gorgonia.GlorotN(1.0)))
+
+	net := gan.Discriminator(
+		&gan.EmbeddingLayer{
+			WeightNode:    embedding_w0,
+			EmbeddingSize: embeddingSize,
+		},
+		&gan.RNNLayer{
+			InputWeightNode:  rnn_input_w0,
+			HiddenWeightNode: rnn_hidden_w0,
+			BiasNode:         rnn_b0,
+			HiddenSize:       hiddenSize,
+		},
+		&gan.LinearLayer{
+			WeightNode: linear_w0,
+			Activation: gan.WithActivationOptions(gan.Softmax, gan.Options{Axis: []int{1}}),
+		},
+	)
+	return net
+}
+
+// buildVocabulary Collects sorted unique words of the corpus
+func buildVocabulary(sentences []string) ([]string, map[string]int) {
+	unique := make(map[string]bool)
+	for _, sentence := range sentences {
+		for _, word := range strings.Fields(sentence) {
+			unique[word] = true
+		}
+	}
+	vocab := make([]string, 0, len(unique))
+	for word := range unique {
+		vocab = append(vocab, word)
+	}
+	sort.Strings(vocab)
+	wordToIndex := make(map[string]int, len(vocab))
+	for i, word := range vocab {
+		wordToIndex[word] = i
+	}
+	return vocab, wordToIndex
+}
+
+// buildWindows Prepares sliding windows: for tokens t[i]...t[i+n-1] target is one-hot encoded t[i+1]...t[i+n]
+func buildWindows(sentences []string, wordToIndex map[string]int, n, vocabSize int) []window {
+	windows := []window{}
+	for _, sentence := range sentences {
+		words := strings.Fields(sentence)
+		tokens := make([]int, len(words))
+		for i, word := range words {
+			tokens[i] = wordToIndex[word]
+		}
+		for i := 0; i+n < len(tokens); i++ {
+			target := make([]float64, n*vocabSize)
+			for j := 0; j < n; j++ {
+				target[j*vocabSize+tokens[i+1+j]] = 1.0
+			}
+			windows = append(windows, window{
+				Input:  tokens[i : i+n],
+				Target: target,
+			})
+		}
+	}
+	return windows
+}
+
+func argmax(values []float64) int {
+	best := 0
+	for i := range values {
+		if values[i] > values[best] {
+			best = i
+		}
+	}
+	return best
+}

--- a/layer_rnn.go
+++ b/layer_rnn.go
@@ -1,0 +1,192 @@
+package gan_go
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"gorgonia.org/gorgonia"
+	"gorgonia.org/tensor"
+)
+
+// RNNLayer Vanilla recurrent layer.
+//
+// For hidden size H:
+//
+//	InputWeightNode holds W of shape [input_features, H]
+//	HiddenWeightNode holds U of shape [H, H]
+//	BiasNode (optional) holds b of shape [1, H]
+//
+// For time step t hidden state is computed as:
+//
+//	h_t = activation(x_t * W + h_prev * U + b)
+//
+// where activation should be Tanh most of times (used if nil).
+//
+// Input must be a tensor of shape [sequence, input_features] or [sequence, batch, input_features].
+// Output is a tensor of hidden states for every time step: [sequence, H] or [sequence, batch, H] respectively.
+//
+// Initial hidden state is a zero-valued node created automatically.
+// Custom one could be provided either via InitialHiddenNode field or as second input node of Fwd() call.
+// Expected shape is [batch, H].
+type RNNLayer struct {
+	InputWeightNode  *gorgonia.Node
+	HiddenWeightNode *gorgonia.Node
+	BiasNode         *gorgonia.Node
+
+	InitialHiddenNode *gorgonia.Node
+
+	HiddenSize int
+	/* Hidden state activation. Should be Tanh most of times (used if nil) */
+	Activation ActivationFunc
+
+	finalHiddenNode *gorgonia.Node
+}
+
+// FinalHidden Returns reference to hidden state node of the last time step. It is set by Fwd() call
+func (layer *RNNLayer) FinalHidden() *gorgonia.Node {
+	return layer.finalHiddenNode
+}
+
+// Fwd Initializates feedforward for provided input
+//
+// inputs - either single input node or (input, initial hidden state) pair
+// batchSize - not used by this layer type since batch size is derived from the input shape
+func (layer *RNNLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
+	var input, hiddenState *gorgonia.Node
+	switch len(inputs) {
+	case 1:
+		input = inputs[0]
+		hiddenState = layer.InitialHiddenNode
+	case 2:
+		input = inputs[0]
+		hiddenState = inputs[1]
+	default:
+		return nil, fmt.Errorf("Layer of type 'rnn' can handle either 1 or 2 input nodes, got %d", len(inputs))
+	}
+	if layer.InputWeightNode == nil {
+		return nil, fmt.Errorf("RNN layer's input weights node is nil")
+	}
+	if layer.HiddenWeightNode == nil {
+		return nil, fmt.Errorf("RNN layer's hidden weights node is nil")
+	}
+	if layer.HiddenSize < 1 {
+		return nil, fmt.Errorf("RNN layer's hidden size should be positive, got %d", layer.HiddenSize)
+	}
+	hiddenSize := layer.HiddenSize
+	if got := layer.InputWeightNode.Shape()[1]; got != hiddenSize {
+		return nil, fmt.Errorf("RNN layer's input weights node should have shape [input_features, %d], got %v", hiddenSize, layer.InputWeightNode.Shape())
+	}
+	if got := layer.HiddenWeightNode.Shape(); got[0] != hiddenSize || got[1] != hiddenSize {
+		return nil, fmt.Errorf("RNN layer's hidden weights node should have shape [%d, %d], got %v", hiddenSize, hiddenSize, got)
+	}
+	activation := layer.Activation
+	if activation == nil {
+		activation = Tanh
+	}
+
+	// Single code path for both [sequence, features] and [sequence, batch, features] inputs
+	squeezeOutput := false
+	if input.Dims() == 2 {
+		squeezeOutput = true
+		reshaped, err := gorgonia.Reshape(input, tensor.Shape{input.Shape()[0], 1, input.Shape()[1]})
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't add batch dimension to RNN layer's input")
+		}
+		input = reshaped
+	}
+	if input.Dims() != 3 {
+		return nil, fmt.Errorf("RNN layer's input should have shape [sequence, input_features] or [sequence, batch, input_features], got %v", input.Shape())
+	}
+	sequenceLength := input.Shape()[0]
+	batch := input.Shape()[1]
+
+	// Zero-valued initial state unless custom one is provided.
+	// Name must be unique in scope of graph: Gorgonia hashes input nodes by type, shape and name only
+	if hiddenState == nil {
+		hiddenState = gorgonia.NewMatrix(input.Graph(), input.Dtype(), gorgonia.WithShape(batch, hiddenSize), gorgonia.WithInit(gorgonia.Zeroes()), gorgonia.WithName(fmt.Sprintf("rnn_%d_initial_hidden", input.ID())))
+	}
+
+	outputs := make([]*gorgonia.Node, sequenceLength)
+	for t := 0; t < sequenceLength; t++ {
+		// x_t of shape [batch, input_features]
+		xt, err := gorgonia.Slice(input, gorgonia.S(t), nil, nil)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Can't slice time step %d of RNN layer's input of shape %v", t, input.Shape())
+		}
+		inputProjection, err := gorgonia.Mul(xt, layer.InputWeightNode)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't multiply time step input and input weights of RNN layer")
+		}
+		hiddenProjection, err := gorgonia.Mul(hiddenState, layer.HiddenWeightNode)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't multiply previous hidden state and hidden weights of RNN layer")
+		}
+		preActivation, err := gorgonia.Add(inputProjection, hiddenProjection)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't sum input and hidden projections of RNN layer")
+		}
+		preActivation, err = addBias(preActivation, layer.BiasNode, batch)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't add bias to pre-activation of RNN layer")
+		}
+		hiddenState, err = activation(preActivation)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't apply activation function to hidden state of RNN layer")
+		}
+		outputs[t], err = gorgonia.Reshape(hiddenState, tensor.Shape{1, batch, hiddenSize})
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't add time dimension to hidden state of RNN layer")
+		}
+	}
+	layer.finalHiddenNode = hiddenState
+
+	layerNonActivated, err := gorgonia.Concat(0, outputs...)
+	if err != nil {
+		return nil, errors.Wrap(err, "Can't concatenate hidden states of RNN layer")
+	}
+	if squeezeOutput {
+		layerNonActivated, err = gorgonia.Reshape(layerNonActivated, tensor.Shape{sequenceLength, hiddenSize})
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't squeeze batch dimension of RNN layer's output")
+		}
+	}
+	return layerNonActivated, nil
+}
+
+// Activate RNN layer does not imply activation of output: activation function is applied inside of the recurrence
+func (layer *RNNLayer) Activate(input *gorgonia.Node) (*gorgonia.Node, error) {
+	return input, nil
+}
+
+// Learnables Returns learnable nodes
+func (layer *RNNLayer) Learnables() gorgonia.Nodes {
+	learnables := make(gorgonia.Nodes, 0, 3)
+	if layer.InputWeightNode != nil {
+		learnables = append(learnables, layer.InputWeightNode)
+	}
+	if layer.HiddenWeightNode != nil {
+		learnables = append(learnables, layer.HiddenWeightNode)
+	}
+	if layer.BiasNode != nil {
+		learnables = append(learnables, layer.BiasNode)
+	}
+	return learnables
+}
+
+// CloneTo Copies layer structure onto the provided graph. Learnables of the copy share underlying tensors with the source layer
+func (layer *RNNLayer) CloneTo(g *gorgonia.ExprGraph, nameSuffix string) (Layer, error) {
+	if layer.InputWeightNode == nil {
+		return nil, fmt.Errorf("RNN layer has nil input weights node")
+	}
+	if layer.HiddenWeightNode == nil {
+		return nil, fmt.Errorf("RNN layer has nil hidden weights node")
+	}
+	return &RNNLayer{
+		InputWeightNode:   cloneLearnableTo(g, layer.InputWeightNode, nameSuffix),
+		HiddenWeightNode:  cloneLearnableTo(g, layer.HiddenWeightNode, nameSuffix),
+		BiasNode:          cloneLearnableTo(g, layer.BiasNode, nameSuffix),
+		InitialHiddenNode: cloneLearnableTo(g, layer.InitialHiddenNode, nameSuffix),
+		HiddenSize:        layer.HiddenSize,
+		Activation:        layer.Activation,
+	}, nil
+}

--- a/layer_rnn_test.go
+++ b/layer_rnn_test.go
@@ -1,0 +1,155 @@
+package gan_go
+
+import (
+	"math"
+	"testing"
+
+	"gorgonia.org/gorgonia"
+	"gorgonia.org/tensor"
+)
+
+// refRNN computes vanilla RNN forward pass with plain loops: x [seq][feat], W [feat][H], U [H][H], b [H]
+func refRNN(x, W, U [][]float64, b []float64, H int) [][]float64 {
+	feat := len(x[0])
+	h := make([]float64, H)
+	out := make([][]float64, len(x))
+	for t := range x {
+		newH := make([]float64, H)
+		for j := 0; j < H; j++ {
+			s := b[j]
+			for k := 0; k < feat; k++ {
+				s += x[t][k] * W[k][j]
+			}
+			for k := 0; k < H; k++ {
+				s += h[k] * U[k][j]
+			}
+			newH[j] = math.Tanh(s)
+		}
+		h = newH
+		out[t] = newH
+	}
+	return out
+}
+
+func buildRNNFixture(t *testing.T) (*gorgonia.ExprGraph, *RNNLayer, *gorgonia.Node, [][]float64) {
+	t.Helper()
+	const (
+		seq  = 3
+		feat = 2
+		H    = 2
+	)
+	wData := make([]float64, feat*H)
+	uData := make([]float64, H*H)
+	bData := make([]float64, H)
+	xData := make([]float64, seq*feat)
+	for i := range wData {
+		wData[i] = math.Sin(float64(i)+1.0) / 2.0
+	}
+	for i := range uData {
+		uData[i] = math.Cos(float64(i)+1.0) / 2.0
+	}
+	for i := range bData {
+		bData[i] = math.Sin(float64(i)*2.0) / 4.0
+	}
+	for i := range xData {
+		xData[i] = math.Cos(float64(i)*3.0) / 2.0
+	}
+
+	x2d := make([][]float64, seq)
+	for i := 0; i < seq; i++ {
+		x2d[i] = xData[i*feat : (i+1)*feat]
+	}
+	w2d := make([][]float64, feat)
+	for k := 0; k < feat; k++ {
+		w2d[k] = wData[k*H : (k+1)*H]
+	}
+	u2d := make([][]float64, H)
+	for k := 0; k < H; k++ {
+		u2d[k] = uData[k*H : (k+1)*H]
+	}
+	want := refRNN(x2d, w2d, u2d, bData, H)
+
+	g := gorgonia.NewGraph()
+	wNode := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(feat, H), gorgonia.WithName("rnn_w"), gorgonia.WithValue(tensor.New(tensor.WithShape(feat, H), tensor.WithBacking(wData))))
+	uNode := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(H, H), gorgonia.WithName("rnn_u"), gorgonia.WithValue(tensor.New(tensor.WithShape(H, H), tensor.WithBacking(uData))))
+	bNode := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(1, H), gorgonia.WithName("rnn_b"), gorgonia.WithValue(tensor.New(tensor.WithShape(1, H), tensor.WithBacking(bData))))
+	xNode := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(seq, feat), gorgonia.WithName("rnn_x"), gorgonia.WithValue(tensor.New(tensor.WithShape(seq, feat), tensor.WithBacking(xData))))
+
+	layer := &RNNLayer{
+		InputWeightNode:  wNode,
+		HiddenWeightNode: uNode,
+		BiasNode:         bNode,
+		HiddenSize:       H,
+	}
+	return g, layer, xNode, want
+}
+
+func TestRNNForward(t *testing.T) {
+	g, layer, xNode, want := buildRNNFixture(t)
+	out, err := layer.Fwd(1, xNode)
+	if err != nil {
+		t.Fatalf("Fwd error: %v", err)
+	}
+	vm := gorgonia.NewTapeMachine(g)
+	defer vm.Close()
+	if err := vm.RunAll(); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	seq := len(want)
+	H := layer.HiddenSize
+	outShape := out.Value().(tensor.Tensor).Shape()
+	if len(outShape) != 2 || outShape[0] != seq || outShape[1] != H {
+		t.Fatalf("output shape: got %v, want [%d %d]", outShape, seq, H)
+	}
+	got := out.Value().Data().([]float64)
+	for i := 0; i < seq; i++ {
+		for k := 0; k < H; k++ {
+			checkFloat(t, "hidden state", got[i*H+k], want[i][k], 1e-12)
+		}
+	}
+	finalHidden := layer.FinalHidden().Value().Data().([]float64)
+	for k := 0; k < H; k++ {
+		checkFloat(t, "final hidden state", finalHidden[k], want[seq-1][k], 1e-12)
+	}
+}
+
+func TestRNNSolverStep(t *testing.T) {
+	g, layer, xNode, _ := buildRNNFixture(t)
+	out, err := layer.Fwd(1, xNode)
+	if err != nil {
+		t.Fatalf("Fwd error: %v", err)
+	}
+	cost, err := gorgonia.Mean(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := gorgonia.Grad(cost, layer.Learnables()...); err != nil {
+		t.Fatalf("Grad error: %v", err)
+	}
+	vm := gorgonia.NewTapeMachine(g, gorgonia.BindDualValues(layer.Learnables()...))
+	defer vm.Close()
+	if err := vm.RunAll(); err != nil {
+		t.Fatalf("vm error: %v", err)
+	}
+	solver := gorgonia.NewVanillaSolver(gorgonia.WithLearnRate(0.1))
+	if err := solver.Step(gorgonia.NodesToValueGrads(layer.Learnables())); err != nil {
+		t.Fatalf("solver step error: %v", err)
+	}
+}
+
+func TestRNNCloneTo(t *testing.T) {
+	_, layer, _, _ := buildRNNFixture(t)
+	g2 := gorgonia.NewGraph()
+	clonedIface, err := layer.CloneTo(g2, "_clone")
+	if err != nil {
+		t.Fatalf("CloneTo error: %v", err)
+	}
+	cloned := clonedIface.(*RNNLayer)
+	if got := len(cloned.Learnables()); got != 3 {
+		t.Errorf("clone learnables count: got %d, want 3", got)
+	}
+	layer.InputWeightNode.Value().Data().([]float64)[0] = 42.0
+	if got := cloned.InputWeightNode.Value().Data().([]float64)[0]; got != 42.0 {
+		t.Errorf("clone does not share weight memory: got %v, want 42.0", got)
+	}
+}


### PR DESCRIPTION
- New `RNNLayer` implementing the `Layer` interface: vanilla recurrence `h_t = activation(x_t * W + h_prev * U + b)` with tanh by default. Same conventions as `LSTMLayer`: sequence input [seq, features] or [seq, batch, features], automatically created zero initial state (custom one via field or extra `Fwd` input), `FinalHidden()`, optional bias.
- `CloneTo` support, so the layer can be used in the discriminator part of GAN.
- New example `cmd/examples/train_rnn`: the same word level language model task as in train_lstm, but with a vanilla RNN. All corpus sentences are continued from their first 4 words without mistakes.
- Tests: forward pass against a hand computed reference (matches to 1e-12 per time step), solver step through the unrolled recurrence, `CloneTo` memory sharing.
