### PR TITLE
Add GRU layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ Current examples folder contains limited set of layer types:
 - [x] Embedding
 - [x] LSTM
 - [x] RNN
+- [x] GRU
 
-_Note #3_: *some layer types (e.g. LSTM, RNN) and examples (train_cnn, train_embedding, train_lstm, train_rnn) are not related to GAN topic itself. They just show how to build neural networks of other kinds with the same set of abstractions*
+_Note #3_: *some layer types (e.g. LSTM, RNN, GRU) and examples (train_cnn, train_embedding, train_lstm, train_rnn, train_gru) are not related to GAN topic itself. They just show how to build neural networks of other kinds with the same set of abstractions*
 
 ## Why
 Just want to do that in Golang ecosystem.
@@ -124,7 +125,7 @@ Current stage of TODO list for future releases:
     - [x] Proper layer type
     - [x] Examples
 - [x] RNN
-- [ ] GRU
+- [x] GRU
 - [x] Embedding    
 
 ## Code explanation

--- a/cmd/examples/train_gru/README.md
+++ b/cmd/examples/train_gru/README.md
@@ -1,0 +1,57 @@
+# Example of how to use GRU layer
+
+This example is not about GAN itself: a small word level language model is trained to continue sentences of a tiny corpus. It is the same task as in the train_lstm and train_rnn examples, but the recurrent layer is a GRU.
+
+Corpus:
+```
+the quick brown fox jumps over the lazy dog
+the little cat sleeps under the warm sun
+a small bird sings in the green garden
+the old dog walks slowly through the park
+a young fox hides behind the tall tree
+```
+
+Network structure:
+```
+input(4 word indices) => embedding(voc=31, dims=16) => gru(inputs=16, hidden=32) => linear(31, 32) + softmax
+```
+
+Every training window is a sequence of 4 words and the target is the same sequence shifted by one word, so the network learns to predict the next word for every position of the window.
+
+Training details: cross entropy loss, Adam solver, learning rate is 0.01, 200 epochs.
+
+After training the network is asked to continue every sentence of the corpus given its first 4 words: the most probable word at the last position of the window is appended and the window slides forward.
+
+Simply execute:
+```shell
+go run main.go
+```
+
+Final output (may vary due the nature of rand() calls):
+```shell
+Vocabulary size: 31
+Number of training windows: 21
+Epoch 0:
+	Loss: 0.11175398077379935
+Epoch 40:
+	Loss: 0.009151617860573811
+Epoch 80:
+	Loss: 0.006481408763310211
+Epoch 120:
+	Loss: 1.756434612467729e-05
+Epoch 160:
+	Loss: 0.011975535533218581
+Epoch 200:
+	Loss: 3.5472588348739104e-06
+Start testing generator after final epoch
+	Seed: the quick brown fox
+	Continued: the quick brown fox jumps over the lazy dog [OK]
+	Seed: the little cat sleeps
+	Continued: the little cat sleeps under the warm sun [OK]
+	Seed: a small bird sings
+	Continued: a small bird sings in the green garden [OK]
+	Seed: the old dog walks
+	Continued: the old dog walks slowly through the park [OK]
+	Seed: a young fox hides
+	Continued: a young fox hides behind the tall tree [OK]
+```

--- a/cmd/examples/train_gru/main.go
+++ b/cmd/examples/train_gru/main.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"strings"
+
+	gan "github.com/LdDl/gan-go"
+	"gorgonia.org/gorgonia"
+	"gorgonia.org/tensor"
+)
+
+var (
+	corpus = []string{
+		"the quick brown fox jumps over the lazy dog",
+		"the little cat sleeps under the warm sun",
+		"a small bird sings in the green garden",
+		"the old dog walks slowly through the park",
+		"a young fox hides behind the tall tree",
+	}
+	sequenceLength = 4
+	embeddingSize  = 16
+	hiddenSize     = 32
+	learningRate   = 0.01
+	numOfEpochs    = 201
+	evalPrint      = 40
+)
+
+type window struct {
+	Input  []int
+	Target []float64
+}
+
+func main() {
+	rand.Seed(1337)
+
+	/* Prepare dataset */
+	vocab, wordToIndex := buildVocabulary(corpus)
+	vocabSize := len(vocab)
+	windows := buildWindows(corpus, wordToIndex, sequenceLength, vocabSize)
+	fmt.Printf("Vocabulary size: %d\n", vocabSize)
+	fmt.Printf("Number of training windows: %d\n", len(windows))
+
+	/* Define Gorgonia's graph */
+	netGraph := gorgonia.NewGraph()
+
+	/* Define neural network */
+	gruNet := defineNet(netGraph, vocabSize)
+
+	/* Prepare tensor for input values */
+	inputNet := gorgonia.NewTensor(netGraph, gorgonia.Int, 1, gorgonia.WithShape(sequenceLength), gorgonia.WithName("gru_train_input"))
+	err := gruNet.Fwd(1, inputNet)
+	if err != nil {
+		panic(err)
+	}
+
+	/* Prepare tensor for target values */
+	targetNet := gorgonia.NewTensor(netGraph, gorgonia.Float64, 2, gorgonia.WithShape(sequenceLength, vocabSize), gorgonia.WithName("gru_train_target"))
+
+	/* Prepare variable for storing neural network's output */
+	var netOut gorgonia.Value
+	gorgonia.Read(gruNet.Out(), &netOut)
+
+	/* Prepare cost node */
+	cost, err := gan.CrossEntropyLoss(gruNet.Out(), targetNet)
+	if err != nil {
+		panic(err)
+	}
+	gorgonia.WithName("gru_loss")(cost)
+
+	/* Define gradients */
+	_, err = gorgonia.Grad(cost, gruNet.Learnables()...)
+	if err != nil {
+		panic(err)
+	}
+
+	/* Prepare variable for storing neural network's cost */
+	var costOut gorgonia.Value
+	gorgonia.Read(cost, &costOut)
+
+	/* Define tape machine */
+	tm := gorgonia.NewTapeMachine(netGraph, gorgonia.BindDualValues(gruNet.Learnables()...))
+	defer tm.Close()
+
+	/* Initialize solver for evaluation graph */
+	solver := gorgonia.NewAdamSolver(gorgonia.WithBatchSize(1), gorgonia.WithLearnRate(learningRate))
+
+	/* Training process */
+	for e := 0; e < numOfEpochs; e++ {
+		for i := range windows {
+			in := tensor.New(tensor.WithShape(sequenceLength), tensor.WithBacking(windows[i].Input))
+			err = gorgonia.Let(inputNet, in)
+			if err != nil {
+				panic(err)
+			}
+			desired := tensor.New(tensor.WithShape(sequenceLength, vocabSize), tensor.WithBacking(windows[i].Target))
+			err = gorgonia.Let(targetNet, desired)
+			if err != nil {
+				panic(err)
+			}
+			/* Run training step */
+			err = tm.RunAll()
+			if err != nil {
+				panic(err)
+			}
+			err = solver.Step(gorgonia.NodesToValueGrads(gruNet.Learnables()))
+			if err != nil {
+				panic(err)
+			}
+			tm.Reset()
+		}
+		// Shuffle training windows
+		rand.Shuffle(len(windows), func(i, j int) { windows[i], windows[j] = windows[j], windows[i] })
+		if e%evalPrint == 0 {
+			fmt.Printf("Epoch %d:\n", e)
+			fmt.Printf("\tLoss: %v\n", costOut)
+		}
+	}
+
+	/* Test: continue every sentence of the corpus from its first words */
+	fmt.Println("Start testing generator after final epoch")
+	dummyTarget := tensor.New(tensor.WithShape(sequenceLength, vocabSize), tensor.WithBacking(make([]float64, sequenceLength*vocabSize)))
+	for _, sentence := range corpus {
+		words := strings.Fields(sentence)
+		seed := make([]int, sequenceLength)
+		for i := 0; i < sequenceLength; i++ {
+			seed[i] = wordToIndex[words[i]]
+		}
+		generated := make([]string, 0, len(words))
+		generated = append(generated, words[:sequenceLength]...)
+		for len(generated) < len(words) {
+			in := tensor.New(tensor.WithShape(sequenceLength), tensor.WithBacking(append([]int{}, seed...)))
+			err = gorgonia.Let(inputNet, in)
+			if err != nil {
+				panic(err)
+			}
+			err = gorgonia.Let(targetNet, dummyTarget)
+			if err != nil {
+				panic(err)
+			}
+			err = tm.RunAll()
+			if err != nil {
+				panic(err)
+			}
+			probabilities := netOut.Data().([]float64)
+			tm.Reset()
+			// Next word is the most probable prediction at the last position of the window
+			nextWord := argmax(probabilities[(sequenceLength-1)*vocabSize : sequenceLength*vocabSize])
+			generated = append(generated, vocab[nextWord])
+			seed = append(seed[1:], nextWord)
+		}
+		matched := "OK"
+		if strings.Join(generated, " ") != sentence {
+			matched = "MISMATCH"
+		}
+		fmt.Printf("\tSeed: %v\n", strings.Join(words[:sequenceLength], " "))
+		fmt.Printf("\tContinued: %v [%s]\n", strings.Join(generated, " "), matched)
+	}
+}
+
+func defineNet(g *gorgonia.ExprGraph, vocabSize int) *gan.DiscriminatorNet {
+	embedding_w0 := gorgonia.NewTensor(g, gorgonia.Float64, 2, gorgonia.WithShape(vocabSize, embeddingSize), gorgonia.WithName("gru_train_embedding_w0"), gorgonia.WithInit(gorgonia.GlorotN(1.0)))
+
+	gru_input_w0 := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(embeddingSize, 3*hiddenSize), gorgonia.WithName("gru_train_input_w0"), gorgonia.WithInit(gorgonia.GlorotN(1.0)))
+	gru_hidden_w0 := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(hiddenSize, 3*hiddenSize), gorgonia.WithName("gru_train_hidden_w0"), gorgonia.WithInit(gorgonia.GlorotN(1.0)))
+	gru_b0 := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(1, 3*hiddenSize), gorgonia.WithName("gru_train_b0"), gorgonia.WithInit(gorgonia.Zeroes()))
+
+	linear_w0 := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(vocabSize, hiddenSize), gorgonia.WithName("gru_train_linear_w0"), gorgonia.WithInit(gorgonia.GlorotN(1.0)))
+
+	net := gan.Discriminator(
+		&gan.EmbeddingLayer{
+			WeightNode:    embedding_w0,
+			EmbeddingSize: embeddingSize,
+		},
+		&gan.GRULayer{
+			InputWeightNode:  gru_input_w0,
+			HiddenWeightNode: gru_hidden_w0,
+			BiasNode:         gru_b0,
+			HiddenSize:       hiddenSize,
+		},
+		&gan.LinearLayer{
+			WeightNode: linear_w0,
+			Activation: gan.WithActivationOptions(gan.Softmax, gan.Options{Axis: []int{1}}),
+		},
+	)
+	return net
+}
+
+// buildVocabulary Collects sorted unique words of the corpus
+func buildVocabulary(sentences []string) ([]string, map[string]int) {
+	unique := make(map[string]bool)
+	for _, sentence := range sentences {
+		for _, word := range strings.Fields(sentence) {
+			unique[word] = true
+		}
+	}
+	vocab := make([]string, 0, len(unique))
+	for word := range unique {
+		vocab = append(vocab, word)
+	}
+	sort.Strings(vocab)
+	wordToIndex := make(map[string]int, len(vocab))
+	for i, word := range vocab {
+		wordToIndex[word] = i
+	}
+	return vocab, wordToIndex
+}
+
+// buildWindows Prepares sliding windows: for tokens t[i]...t[i+n-1] target is one-hot encoded t[i+1]...t[i+n]
+func buildWindows(sentences []string, wordToIndex map[string]int, n, vocabSize int) []window {
+	windows := []window{}
+	for _, sentence := range sentences {
+		words := strings.Fields(sentence)
+		tokens := make([]int, len(words))
+		for i, word := range words {
+			tokens[i] = wordToIndex[word]
+		}
+		for i := 0; i+n < len(tokens); i++ {
+			target := make([]float64, n*vocabSize)
+			for j := 0; j < n; j++ {
+				target[j*vocabSize+tokens[i+1+j]] = 1.0
+			}
+			windows = append(windows, window{
+				Input:  tokens[i : i+n],
+				Target: target,
+			})
+		}
+	}
+	return windows
+}
+
+func argmax(values []float64) int {
+	best := 0
+	for i := range values {
+		if values[i] > values[best] {
+			best = i
+		}
+	}
+	return best
+}

--- a/layer.go
+++ b/layer.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	"gorgonia.org/gorgonia"
+	"gorgonia.org/tensor"
 )
 
 // Layer Interface for a single layer of a neural network.
@@ -77,6 +78,30 @@ func cloneLearnableTo(g *gorgonia.ExprGraph, node *gorgonia.Node, nameSuffix str
 		return nil
 	}
 	return gorgonia.NewTensor(g, node.Dtype(), node.Dims(), gorgonia.WithShape(node.Shape()...), gorgonia.WithName(node.Name()+nameSuffix), gorgonia.WithValue(node.Value()))
+}
+
+// sliceGate Extracts single gate (columns [idx*hiddenSize; (idx+1)*hiddenSize)) of a recurrent layer
+// and applies activation function to it.
+//
+// Three implementation notes:
+// 1. Slice of a node is a view sharing memory with the sliced node. Binary operations of Gorgonia
+// may write their result into the buffer of an operand, corrupting the source tensor,
+// so views are passed to unary operations only.
+// 2. Sliced gate is reshaped explicitly since slicing range of width 1 collapses the dimension.
+// 3. Order matters: reshape must be applied BEFORE the activation function.
+// The reversed order (slice, activation, reshape) produces incorrect gradients in the backward
+// pass of Gorgonia, which is verified by numerical gradient checks in the tests
+func sliceGate(gates *gorgonia.Node, idx, hiddenSize int, activation ActivationFunc) (*gorgonia.Node, error) {
+	batch := gates.Shape()[0]
+	gate, err := gorgonia.Slice(gates, nil, gorgonia.S(idx*hiddenSize, (idx+1)*hiddenSize))
+	if err != nil {
+		return nil, errors.Wrap(err, "Can't slice gate")
+	}
+	reshaped, err := gorgonia.Reshape(gate, tensor.Shape{batch, hiddenSize})
+	if err != nil {
+		return nil, errors.Wrap(err, "Can't reshape sliced gate")
+	}
+	return activation(reshaped)
 }
 
 func checkF64ValueInRange(input, min, max float64) bool {

--- a/layer_gradients_test.go
+++ b/layer_gradients_test.go
@@ -1,0 +1,92 @@
+package gan_go
+
+import (
+	"math"
+	"testing"
+
+	"gorgonia.org/gorgonia"
+)
+
+// numericGradCheck compares analytic gradients of the loss w.r.t. learnables
+// against central finite differences. It guards against silently broken backward passes
+// (e.g. wrong gradients of slice/reshape/activation combinations inside recurrent layers)
+func numericGradCheck(t *testing.T, g *gorgonia.ExprGraph, out *gorgonia.Node, learnables gorgonia.Nodes) {
+	t.Helper()
+	cost, err := gorgonia.Mean(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := gorgonia.Grad(cost, learnables...); err != nil {
+		t.Fatalf("Grad error: %v", err)
+	}
+	var costVal gorgonia.Value
+	gorgonia.Read(cost, &costVal)
+	vm := gorgonia.NewTapeMachine(g, gorgonia.BindDualValues(learnables...))
+	defer vm.Close()
+
+	run := func() float64 {
+		if err := vm.RunAll(); err != nil {
+			t.Fatalf("vm error: %v", err)
+		}
+		c := costVal.Data().(float64)
+		vm.Reset()
+		return c
+	}
+	run()
+
+	// Snapshot of analytic gradients must be taken for ALL learnables right after the very first run:
+	// tape machine accumulates gradients over RunAll calls, so values read after
+	// the finite difference runs below would be summed multiple times
+	analytic := make([][]float64, len(learnables))
+	for i, learnable := range learnables {
+		grad, err := learnable.Grad()
+		if err != nil {
+			t.Fatalf("no gradient for %s: %v", learnable.Name(), err)
+		}
+		analytic[i] = append([]float64{}, grad.Data().([]float64)...)
+	}
+
+	const eps = 1e-6
+	for li, learnable := range learnables {
+		backing := learnable.Value().Data().([]float64)
+		for i := range backing {
+			orig := backing[i]
+			backing[i] = orig + eps
+			costPlus := run()
+			backing[i] = orig - eps
+			costMinus := run()
+			backing[i] = orig
+			numeric := (costPlus - costMinus) / (2 * eps)
+			if math.Abs(numeric-analytic[li][i]) > 1e-6 {
+				t.Errorf("%s gradient [%d]: analytic %v, numeric %v", learnable.Name(), i, analytic[li][i], numeric)
+			}
+		}
+	}
+}
+
+func TestLSTMGradients(t *testing.T) {
+	g, layer, xNode, _ := buildLSTMFixture(t)
+	out, err := layer.Fwd(1, xNode)
+	if err != nil {
+		t.Fatalf("Fwd error: %v", err)
+	}
+	numericGradCheck(t, g, out, layer.Learnables())
+}
+
+func TestGRUGradients(t *testing.T) {
+	g, layer, xNode, _ := buildGRUFixture(t)
+	out, err := layer.Fwd(1, xNode)
+	if err != nil {
+		t.Fatalf("Fwd error: %v", err)
+	}
+	numericGradCheck(t, g, out, layer.Learnables())
+}
+
+func TestRNNGradients(t *testing.T) {
+	g, layer, xNode, _ := buildRNNFixture(t)
+	out, err := layer.Fwd(1, xNode)
+	if err != nil {
+		t.Fatalf("Fwd error: %v", err)
+	}
+	numericGradCheck(t, g, out, layer.Learnables())
+}

--- a/layer_gru.go
+++ b/layer_gru.go
@@ -1,0 +1,252 @@
+package gan_go
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"gorgonia.org/gorgonia"
+	"gorgonia.org/tensor"
+)
+
+// GRULayer Gated recurrent unit layer (formulation of Cho et al., 2014).
+//
+// All three gates (reset, update, candidate) are packed into single weight matrices,
+// so for hidden size H:
+//
+//	InputWeightNode holds W of shape [input_features, 3*H]
+//	HiddenWeightNode holds U of shape [H, 3*H]
+//	BiasNode (optional) holds b of shape [1, 3*H], applied to the input projection
+//
+// For time step t (gate columns order is reset, update, candidate):
+//
+//	r_t = sigmoid((x_t * W + b)_r + (h_prev * U)_r)
+//	z_t = sigmoid((x_t * W + b)_z + (h_prev * U)_z)
+//	n_t = tanh((x_t * W + b)_n + ((r_t ⊙ h_prev) * U)_n)
+//	h_t = (1 - z_t) ⊙ n_t + z_t ⊙ h_prev
+//
+// where sigmoid could be replaced via RecurrentActivation and tanh via Activation.
+//
+// Input must be a tensor of shape [sequence, input_features] or [sequence, batch, input_features].
+// Output is a tensor of hidden states for every time step: [sequence, H] or [sequence, batch, H] respectively.
+//
+// Initial hidden state is a zero-valued node created automatically.
+// Custom one could be provided either via InitialHiddenNode field or as second input node of Fwd() call.
+// Expected shape is [batch, H].
+type GRULayer struct {
+	InputWeightNode  *gorgonia.Node
+	HiddenWeightNode *gorgonia.Node
+	BiasNode         *gorgonia.Node
+
+	InitialHiddenNode *gorgonia.Node
+
+	HiddenSize int
+	/* Candidate activation. Should be Tanh most of times (used if nil) */
+	Activation ActivationFunc
+	/* Reset and update gates activation. Should be Sigmoid most of times (used if nil) */
+	RecurrentActivation ActivationFunc
+
+	finalHiddenNode *gorgonia.Node
+}
+
+// FinalHidden Returns reference to hidden state node of the last time step. It is set by Fwd() call
+func (layer *GRULayer) FinalHidden() *gorgonia.Node {
+	return layer.finalHiddenNode
+}
+
+// Fwd Initializates feedforward for provided input
+//
+// inputs - either single input node or (input, initial hidden state) pair
+// batchSize - not used by this layer type since batch size is derived from the input shape
+func (layer *GRULayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
+	var input, hiddenState *gorgonia.Node
+	switch len(inputs) {
+	case 1:
+		input = inputs[0]
+		hiddenState = layer.InitialHiddenNode
+	case 2:
+		input = inputs[0]
+		hiddenState = inputs[1]
+	default:
+		return nil, fmt.Errorf("Layer of type 'gru' can handle either 1 or 2 input nodes, got %d", len(inputs))
+	}
+	if layer.InputWeightNode == nil {
+		return nil, fmt.Errorf("GRU layer's input weights node is nil")
+	}
+	if layer.HiddenWeightNode == nil {
+		return nil, fmt.Errorf("GRU layer's hidden weights node is nil")
+	}
+	if layer.HiddenSize < 1 {
+		return nil, fmt.Errorf("GRU layer's hidden size should be positive, got %d", layer.HiddenSize)
+	}
+	hiddenSize := layer.HiddenSize
+	if got := layer.InputWeightNode.Shape()[1]; got != 3*hiddenSize {
+		return nil, fmt.Errorf("GRU layer's input weights node should have shape [input_features, %d], got %v", 3*hiddenSize, layer.InputWeightNode.Shape())
+	}
+	if got := layer.HiddenWeightNode.Shape(); got[0] != hiddenSize || got[1] != 3*hiddenSize {
+		return nil, fmt.Errorf("GRU layer's hidden weights node should have shape [%d, %d], got %v", hiddenSize, 3*hiddenSize, got)
+	}
+	candidateActivation := layer.Activation
+	if candidateActivation == nil {
+		candidateActivation = Tanh
+	}
+	gatesActivation := layer.RecurrentActivation
+	if gatesActivation == nil {
+		gatesActivation = Sigmoid
+	}
+
+	// Single code path for both [sequence, features] and [sequence, batch, features] inputs
+	squeezeOutput := false
+	if input.Dims() == 2 {
+		squeezeOutput = true
+		reshaped, err := gorgonia.Reshape(input, tensor.Shape{input.Shape()[0], 1, input.Shape()[1]})
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't add batch dimension to GRU layer's input")
+		}
+		input = reshaped
+	}
+	if input.Dims() != 3 {
+		return nil, fmt.Errorf("GRU layer's input should have shape [sequence, input_features] or [sequence, batch, input_features], got %v", input.Shape())
+	}
+	sequenceLength := input.Shape()[0]
+	batch := input.Shape()[1]
+
+	// Zero-valued initial state unless custom one is provided.
+	// Name must be unique in scope of graph: Gorgonia hashes input nodes by type, shape and name only
+	if hiddenState == nil {
+		hiddenState = gorgonia.NewMatrix(input.Graph(), input.Dtype(), gorgonia.WithShape(batch, hiddenSize), gorgonia.WithInit(gorgonia.Zeroes()), gorgonia.WithName(fmt.Sprintf("gru_%d_initial_hidden", input.ID())))
+	}
+	// Zero-valued node for detaching stored outputs from hidden state buffers.
+	// Tape machine of Gorgonia is free to reuse a buffer of a node for the result of the last
+	// operation reading that node (in-place optimization). Element-wise operations of the next
+	// time step do read the hidden state, while the stored output references its buffer through
+	// a reshape view invisible to the liveness analysis. Summation with zeros materializes
+	// a standalone copy, so stored outputs survive such buffer reuse
+	outputAnchor := gorgonia.NewMatrix(input.Graph(), input.Dtype(), gorgonia.WithShape(batch, hiddenSize), gorgonia.WithInit(gorgonia.Zeroes()), gorgonia.WithName(fmt.Sprintf("gru_%d_output_anchor", input.ID())))
+
+	outputs := make([]*gorgonia.Node, sequenceLength)
+	for t := 0; t < sequenceLength; t++ {
+		// x_t of shape [batch, input_features]
+		xt, err := gorgonia.Slice(input, gorgonia.S(t), nil, nil)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Can't slice time step %d of GRU layer's input of shape %v", t, input.Shape())
+		}
+		inputProjection, err := gorgonia.Mul(xt, layer.InputWeightNode)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't multiply time step input and input weights of GRU layer")
+		}
+		inputProjection, err = addBias(inputProjection, layer.BiasNode, batch)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't add bias to input projection of GRU layer")
+		}
+		hiddenProjection, err := gorgonia.Mul(hiddenState, layer.HiddenWeightNode)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't multiply previous hidden state and hidden weights of GRU layer")
+		}
+		// Reset and update gates.
+		// Note: hidden projection is intentionally the first operand. Some element-wise operations
+		// of Gorgonia write their result into the buffer of the first operand, so a node which is
+		// read again later (input projection here) must not be placed first
+		gates, err := gorgonia.Add(hiddenProjection, inputProjection)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't sum input and hidden projections of GRU layer")
+		}
+		resetGate, err := sliceGate(gates, 0, hiddenSize, gatesActivation)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't extract reset gate of GRU layer")
+		}
+		updateGate, err := sliceGate(gates, 1, hiddenSize, gatesActivation)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't extract update gate of GRU layer")
+		}
+		// Candidate: reset gate is applied to the previous hidden state before the projection
+		hiddenGated, err := gorgonia.HadamardProd(resetGate, hiddenState)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't apply reset gate to previous hidden state of GRU layer")
+		}
+		hiddenGatedProjection, err := gorgonia.Mul(hiddenGated, layer.HiddenWeightNode)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't multiply gated hidden state and hidden weights of GRU layer")
+		}
+		candidateSum, err := gorgonia.Add(hiddenGatedProjection, inputProjection)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't sum input and gated hidden projections of GRU layer")
+		}
+		candidate, err := sliceGate(candidateSum, 2, hiddenSize, candidateActivation)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't extract candidate of GRU layer")
+		}
+		// h_t = (1 - z) ⊙ n + z ⊙ h_prev, computed as n + z ⊙ (h_prev - n)
+		hiddenSubCandidate, err := gorgonia.Sub(hiddenState, candidate)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't subtract candidate from previous hidden state of GRU layer")
+		}
+		keptPart, err := gorgonia.HadamardProd(updateGate, hiddenSubCandidate)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't apply update gate of GRU layer")
+		}
+		hiddenState, err = gorgonia.Add(candidate, keptPart)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't update hidden state of GRU layer")
+		}
+		outputCopy, err := gorgonia.Add(hiddenState, outputAnchor)
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't copy hidden state of GRU layer for storing")
+		}
+		outputs[t], err = gorgonia.Reshape(outputCopy, tensor.Shape{1, batch, hiddenSize})
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't add time dimension to hidden state of GRU layer")
+		}
+	}
+	layer.finalHiddenNode = hiddenState
+
+	layerNonActivated, err := gorgonia.Concat(0, outputs...)
+	if err != nil {
+		return nil, errors.Wrap(err, "Can't concatenate hidden states of GRU layer")
+	}
+	if squeezeOutput {
+		layerNonActivated, err = gorgonia.Reshape(layerNonActivated, tensor.Shape{sequenceLength, hiddenSize})
+		if err != nil {
+			return nil, errors.Wrap(err, "Can't squeeze batch dimension of GRU layer's output")
+		}
+	}
+	return layerNonActivated, nil
+}
+
+// Activate GRU layer does not imply activation of output: activation functions are applied inside of the cell
+func (layer *GRULayer) Activate(input *gorgonia.Node) (*gorgonia.Node, error) {
+	return input, nil
+}
+
+// Learnables Returns learnable nodes
+func (layer *GRULayer) Learnables() gorgonia.Nodes {
+	learnables := make(gorgonia.Nodes, 0, 3)
+	if layer.InputWeightNode != nil {
+		learnables = append(learnables, layer.InputWeightNode)
+	}
+	if layer.HiddenWeightNode != nil {
+		learnables = append(learnables, layer.HiddenWeightNode)
+	}
+	if layer.BiasNode != nil {
+		learnables = append(learnables, layer.BiasNode)
+	}
+	return learnables
+}
+
+// CloneTo Copies layer structure onto the provided graph. Learnables of the copy share underlying tensors with the source layer
+func (layer *GRULayer) CloneTo(g *gorgonia.ExprGraph, nameSuffix string) (Layer, error) {
+	if layer.InputWeightNode == nil {
+		return nil, fmt.Errorf("GRU layer has nil input weights node")
+	}
+	if layer.HiddenWeightNode == nil {
+		return nil, fmt.Errorf("GRU layer has nil hidden weights node")
+	}
+	return &GRULayer{
+		InputWeightNode:     cloneLearnableTo(g, layer.InputWeightNode, nameSuffix),
+		HiddenWeightNode:    cloneLearnableTo(g, layer.HiddenWeightNode, nameSuffix),
+		BiasNode:            cloneLearnableTo(g, layer.BiasNode, nameSuffix),
+		InitialHiddenNode:   cloneLearnableTo(g, layer.InitialHiddenNode, nameSuffix),
+		HiddenSize:          layer.HiddenSize,
+		Activation:          layer.Activation,
+		RecurrentActivation: layer.RecurrentActivation,
+	}, nil
+}

--- a/layer_gru_test.go
+++ b/layer_gru_test.go
@@ -8,55 +8,60 @@ import (
 	"gorgonia.org/tensor"
 )
 
-func sigmoidRef(x float64) float64 {
-	return 1.0 / (1.0 + math.Exp(-x))
-}
-
-// refLSTM computes LSTM forward pass with plain loops: x [seq][feat], W [feat][4H], U [H][4H], b [4H].
-// Gate columns order matches LSTMLayer: input, forget, cell candidate, output
-func refLSTM(x, W, U [][]float64, b []float64, H int) [][]float64 {
+// refGRU computes GRU forward pass with plain loops: x [seq][feat], W [feat][3H], U [H][3H], b [3H].
+// Gate columns order matches GRULayer: reset, update, candidate.
+// Bias is applied to the input projection only. Reset gate is applied to the previous hidden state
+// before the projection (formulation of Cho et al., 2014)
+func refGRU(x, W, U [][]float64, b []float64, H int) [][]float64 {
 	feat := len(x[0])
 	h := make([]float64, H)
-	c := make([]float64, H)
 	out := make([][]float64, len(x))
 	for t := range x {
-		gates := make([]float64, 4*H)
-		for j := 0; j < 4*H; j++ {
+		xProj := make([]float64, 3*H)
+		hProj := make([]float64, 3*H)
+		for j := 0; j < 3*H; j++ {
 			s := b[j]
 			for k := 0; k < feat; k++ {
 				s += x[t][k] * W[k][j]
 			}
+			xProj[j] = s
+			s = 0.0
 			for k := 0; k < H; k++ {
 				s += h[k] * U[k][j]
 			}
-			gates[j] = s
+			hProj[j] = s
+		}
+		resetGate := make([]float64, H)
+		updateGate := make([]float64, H)
+		for k := 0; k < H; k++ {
+			resetGate[k] = sigmoidRef(xProj[k] + hProj[k])
+			updateGate[k] = sigmoidRef(xProj[H+k] + hProj[H+k])
 		}
 		newH := make([]float64, H)
-		newC := make([]float64, H)
 		for k := 0; k < H; k++ {
-			inputGate := sigmoidRef(gates[k])
-			forgetGate := sigmoidRef(gates[H+k])
-			cellCandidate := math.Tanh(gates[2*H+k])
-			outputGate := sigmoidRef(gates[3*H+k])
-			newC[k] = forgetGate*c[k] + inputGate*cellCandidate
-			newH[k] = outputGate * math.Tanh(newC[k])
+			gatedProj := 0.0
+			for j := 0; j < H; j++ {
+				gatedProj += resetGate[j] * h[j] * U[j][2*H+k]
+			}
+			candidate := math.Tanh(xProj[2*H+k] + gatedProj)
+			newH[k] = (1.0-updateGate[k])*candidate + updateGate[k]*h[k]
 		}
-		h, c = newH, newC
+		h = newH
 		out[t] = newH
 	}
 	return out
 }
 
-func buildLSTMFixture(t *testing.T) (*gorgonia.ExprGraph, *LSTMLayer, *gorgonia.Node, [][]float64) {
+func buildGRUFixture(t *testing.T) (*gorgonia.ExprGraph, *GRULayer, *gorgonia.Node, [][]float64) {
 	t.Helper()
 	const (
 		seq  = 3
 		feat = 2
 		H    = 2
 	)
-	wData := make([]float64, feat*4*H)
-	uData := make([]float64, H*4*H)
-	bData := make([]float64, 4*H)
+	wData := make([]float64, feat*3*H)
+	uData := make([]float64, H*3*H)
+	bData := make([]float64, 3*H)
 	xData := make([]float64, seq*feat)
 	for i := range wData {
 		wData[i] = math.Sin(float64(i)+1.0) / 2.0
@@ -77,21 +82,21 @@ func buildLSTMFixture(t *testing.T) (*gorgonia.ExprGraph, *LSTMLayer, *gorgonia.
 	}
 	w2d := make([][]float64, feat)
 	for k := 0; k < feat; k++ {
-		w2d[k] = wData[k*4*H : (k+1)*4*H]
+		w2d[k] = wData[k*3*H : (k+1)*3*H]
 	}
 	u2d := make([][]float64, H)
 	for k := 0; k < H; k++ {
-		u2d[k] = uData[k*4*H : (k+1)*4*H]
+		u2d[k] = uData[k*3*H : (k+1)*3*H]
 	}
-	want := refLSTM(x2d, w2d, u2d, bData, H)
+	want := refGRU(x2d, w2d, u2d, bData, H)
 
 	g := gorgonia.NewGraph()
-	wNode := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(feat, 4*H), gorgonia.WithName("lstm_w"), gorgonia.WithValue(tensor.New(tensor.WithShape(feat, 4*H), tensor.WithBacking(wData))))
-	uNode := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(H, 4*H), gorgonia.WithName("lstm_u"), gorgonia.WithValue(tensor.New(tensor.WithShape(H, 4*H), tensor.WithBacking(uData))))
-	bNode := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(1, 4*H), gorgonia.WithName("lstm_b"), gorgonia.WithValue(tensor.New(tensor.WithShape(1, 4*H), tensor.WithBacking(bData))))
-	xNode := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(seq, feat), gorgonia.WithName("lstm_x"), gorgonia.WithValue(tensor.New(tensor.WithShape(seq, feat), tensor.WithBacking(xData))))
+	wNode := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(feat, 3*H), gorgonia.WithName("gru_w"), gorgonia.WithValue(tensor.New(tensor.WithShape(feat, 3*H), tensor.WithBacking(wData))))
+	uNode := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(H, 3*H), gorgonia.WithName("gru_u"), gorgonia.WithValue(tensor.New(tensor.WithShape(H, 3*H), tensor.WithBacking(uData))))
+	bNode := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(1, 3*H), gorgonia.WithName("gru_b"), gorgonia.WithValue(tensor.New(tensor.WithShape(1, 3*H), tensor.WithBacking(bData))))
+	xNode := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(seq, feat), gorgonia.WithName("gru_x"), gorgonia.WithValue(tensor.New(tensor.WithShape(seq, feat), tensor.WithBacking(xData))))
 
-	layer := &LSTMLayer{
+	layer := &GRULayer{
 		InputWeightNode:  wNode,
 		HiddenWeightNode: uNode,
 		BiasNode:         bNode,
@@ -100,8 +105,8 @@ func buildLSTMFixture(t *testing.T) (*gorgonia.ExprGraph, *LSTMLayer, *gorgonia.
 	return g, layer, xNode, want
 }
 
-func TestLSTMForward(t *testing.T) {
-	g, layer, xNode, want := buildLSTMFixture(t)
+func TestGRUForward(t *testing.T) {
+	g, layer, xNode, want := buildGRUFixture(t)
 	out, err := layer.Fwd(1, xNode)
 	if err != nil {
 		t.Fatalf("Fwd error: %v", err)
@@ -129,8 +134,8 @@ func TestLSTMForward(t *testing.T) {
 	}
 }
 
-func TestLSTMSolverStep(t *testing.T) {
-	g, layer, xNode, _ := buildLSTMFixture(t)
+func TestGRUSolverStep(t *testing.T) {
+	g, layer, xNode, _ := buildGRUFixture(t)
 	out, err := layer.Fwd(1, xNode)
 	if err != nil {
 		t.Fatalf("Fwd error: %v", err)
@@ -153,33 +158,33 @@ func TestLSTMSolverStep(t *testing.T) {
 	}
 }
 
-// TestLSTMHiddenSizeOne guards against dimension collapse when slicing ranges of width 1
-func TestLSTMHiddenSizeOne(t *testing.T) {
+// TestGRUHiddenSizeOne guards against dimension collapse when slicing ranges of width 1
+func TestGRUHiddenSizeOne(t *testing.T) {
 	const (
 		seq  = 2
 		feat = 2
 		H    = 1
 	)
-	wData := []float64{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8}
-	uData := []float64{0.15, 0.25, 0.35, 0.45}
-	bData := []float64{0.01, 0.02, 0.03, 0.04}
+	wData := []float64{0.1, 0.2, 0.3, 0.4, 0.5, 0.6}
+	uData := []float64{0.7, 0.8, 0.9}
+	bData := []float64{0.01, 0.02, 0.03}
 	xData := []float64{0.5, 0.6, 0.7, 0.8}
 
-	want := refLSTM(
+	want := refGRU(
 		[][]float64{xData[0:2], xData[2:4]},
-		[][]float64{wData[0:4], wData[4:8]},
+		[][]float64{wData[0:3], wData[3:6]},
 		[][]float64{uData},
 		bData,
 		H,
 	)
 
 	g := gorgonia.NewGraph()
-	wNode := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(feat, 4*H), gorgonia.WithName("lstm1_w"), gorgonia.WithValue(tensor.New(tensor.WithShape(feat, 4*H), tensor.WithBacking(wData))))
-	uNode := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(H, 4*H), gorgonia.WithName("lstm1_u"), gorgonia.WithValue(tensor.New(tensor.WithShape(H, 4*H), tensor.WithBacking(uData))))
-	bNode := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(1, 4*H), gorgonia.WithName("lstm1_b"), gorgonia.WithValue(tensor.New(tensor.WithShape(1, 4*H), tensor.WithBacking(bData))))
-	xNode := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(seq, feat), gorgonia.WithName("lstm1_x"), gorgonia.WithValue(tensor.New(tensor.WithShape(seq, feat), tensor.WithBacking(xData))))
+	wNode := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(feat, 3*H), gorgonia.WithName("gru1_w"), gorgonia.WithValue(tensor.New(tensor.WithShape(feat, 3*H), tensor.WithBacking(wData))))
+	uNode := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(H, 3*H), gorgonia.WithName("gru1_u"), gorgonia.WithValue(tensor.New(tensor.WithShape(H, 3*H), tensor.WithBacking(uData))))
+	bNode := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(1, 3*H), gorgonia.WithName("gru1_b"), gorgonia.WithValue(tensor.New(tensor.WithShape(1, 3*H), tensor.WithBacking(bData))))
+	xNode := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(seq, feat), gorgonia.WithName("gru1_x"), gorgonia.WithValue(tensor.New(tensor.WithShape(seq, feat), tensor.WithBacking(xData))))
 
-	layer := &LSTMLayer{
+	layer := &GRULayer{
 		InputWeightNode:  wNode,
 		HiddenWeightNode: uNode,
 		BiasNode:         bNode,
@@ -200,14 +205,14 @@ func TestLSTMHiddenSizeOne(t *testing.T) {
 	}
 }
 
-func TestLSTMCloneTo(t *testing.T) {
-	_, layer, _, _ := buildLSTMFixture(t)
+func TestGRUCloneTo(t *testing.T) {
+	_, layer, _, _ := buildGRUFixture(t)
 	g2 := gorgonia.NewGraph()
 	clonedIface, err := layer.CloneTo(g2, "_clone")
 	if err != nil {
 		t.Fatalf("CloneTo error: %v", err)
 	}
-	cloned := clonedIface.(*LSTMLayer)
+	cloned := clonedIface.(*GRULayer)
 	if got := len(cloned.Learnables()); got != 3 {
 		t.Errorf("clone learnables count: got %d, want 3", got)
 	}

--- a/layer_lstm.go
+++ b/layer_lstm.go
@@ -209,15 +209,6 @@ func (layer *LSTMLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.
 	return layerNonActivated, nil
 }
 
-// sliceGate Extracts single gate (columns [idx*hiddenSize; (idx+1)*hiddenSize)) and applies activation function to it
-func sliceGate(gates *gorgonia.Node, idx, hiddenSize int, activation ActivationFunc) (*gorgonia.Node, error) {
-	gate, err := gorgonia.Slice(gates, nil, gorgonia.S(idx*hiddenSize, (idx+1)*hiddenSize))
-	if err != nil {
-		return nil, errors.Wrap(err, "Can't slice gate")
-	}
-	return activation(gate)
-}
-
 // Activate LSTM layer does not imply activation of output: activation functions are applied inside of the cell
 func (layer *LSTMLayer) Activate(input *gorgonia.Node) (*gorgonia.Node, error) {
 	return input, nil


### PR DESCRIPTION
- New `GRULayer` implementing the `Layer` interface (formulation of Cho et al., 2014). All three gates (reset, update, candidate) are packed into single weight matrices: `InputWeightNode` [features, 3H], `HiddenWeightNode` [H, 3H] and optional `BiasNode` [1, 3H]. Same conventions as the other recurrent layers: sequence input, automatically created zero initial state, `FinalHidden()`, configurable activations, `CloneTo` for usage inside GAN discriminator.
- New example `cmd/examples/train_gru`: the same word level language model task as in train_lstm/train_rnn. All corpus sentences are continued from their first 4 words without mistakes.
- GRU stores per-step outputs through a materialized copy: Gorgonia's tape machine may reuse a buffer of a node once its liveness ends, while reshape views referencing that buffer are invisible to the liveness analysis.

Forward pass is verified against a hand computed reference (matches to 1e-12 per time step), gradients are verified numerically.

P.S. The `sliceGate` helper now reshapes gates explicitly (fixes dimension collapse for hidden size 1, covered by tests) and moved to layer.go to shared helpers. Note for future contributors, verified by the gradient checks: reshape must be applied before the activation function, the reversed order produces incorrect gradients in Gorgonia's backward pass.
