### PR TITLE
[BREAKING] Derive batch size from input shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Current stage of TODO list for future releases:
 - [x] Reduce duplicating of code for *.Fwd()* method of each neural network type (GAN/Discriminator/Generator)
 - [x] Switch **Layer** from *struct* to *interface* or use other technique for building clean code
 - [x] Add basic layers: Linear, Convolutional, Maxpool, Flatten
-- [ ] Deal with batch process 
+- [x] Deal with batch process 
 - [x] More loss function
     - [x] Cross Entropy
     - [x] Binary Cross Entropy

--- a/cmd/examples/generate_smiley_face/main.go
+++ b/cmd/examples/generate_smiley_face/main.go
@@ -79,7 +79,7 @@ func main() {
 	definedGenerator := defineGenerator(ganGraph)
 	// Initialize Generator feedforward
 	inputGenerator := gorgonia.NewTensor(ganGraph, gorgonia.Float64, 4, gorgonia.WithShape(latentShape...), gorgonia.WithName("generator_input"))
-	err := definedGenerator.Fwd(batchSize, inputGenerator)
+	err := definedGenerator.Fwd(inputGenerator)
 	if err != nil {
 		panic(err)
 	}
@@ -88,7 +88,7 @@ func main() {
 	discriminatorTrain := defineDiscriminator(trainDiscriminatorGraph)
 	// Initialize Discriminator feedforward
 	inputDiscriminatorTrain := gorgonia.NewTensor(trainDiscriminatorGraph, gorgonia.Float64, 4, gorgonia.WithShape(2*batchSize, imgChannels, imgHeight, imgWidth), gorgonia.WithName("discriminator_train_input"))
-	err = discriminatorTrain.Fwd(2*batchSize, inputDiscriminatorTrain)
+	err = discriminatorTrain.Fwd(inputDiscriminatorTrain)
 	if err != nil {
 		panic(err)
 	}
@@ -98,7 +98,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	err = definedGAN.Fwd(batchSize)
+	err = definedGAN.Fwd()
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/examples/generate_symbol/main.go
+++ b/cmd/examples/generate_symbol/main.go
@@ -77,7 +77,7 @@ func main() {
 	definedGenerator := defineGenerator(ganGraph)
 	// Initialize Generator feedforward
 	inputGenerator := gorgonia.NewMatrix(ganGraph, gorgonia.Float64, gorgonia.WithShape(batchSize, latentSpaceSize), gorgonia.WithName("generator_input"))
-	err := definedGenerator.Fwd(batchSize, inputGenerator)
+	err := definedGenerator.Fwd(inputGenerator)
 	if err != nil {
 		panic(err)
 	}
@@ -86,14 +86,14 @@ func main() {
 	discriminatorTrain := defineDiscriminator(trainDiscriminatorGraph)
 	// Initialize Discriminator feedforward
 	inputDiscriminatorTrain := gorgonia.NewMatrix(trainDiscriminatorGraph, gorgonia.Float64, gorgonia.WithShape(2*batchSize, symbolHeight*symbolWidth), gorgonia.WithName("discriminator_train_input"))
-	discriminatorTrain.Fwd(2*batchSize, inputDiscriminatorTrain)
+	discriminatorTrain.Fwd(inputDiscriminatorTrain)
 
 	// Define GAN on the same evaluation graph as Generator has been defined
 	definedGAN, err := gan.NewGAN(ganGraph, definedGenerator, discriminatorTrain)
 	if err != nil {
 		panic(err)
 	}
-	definedGAN.Fwd(batchSize)
+	definedGAN.Fwd()
 
 	/* Define variables for reading evaluation graphs' (both GAN and Discriminator in training mode) output */
 	// GAN Generator output

--- a/cmd/examples/parabola/main.go
+++ b/cmd/examples/parabola/main.go
@@ -64,7 +64,7 @@ func main() {
 	definedGenerator := defineGenerator(ganGraph)
 	// Initialize Generator feedforward
 	inputGenerator := gorgonia.NewMatrix(ganGraph, gorgonia.Float64, gorgonia.WithShape(batchSize, latentSpaceSize), gorgonia.WithName("generator_input"))
-	err = definedGenerator.Fwd(batchSize, inputGenerator)
+	err = definedGenerator.Fwd(inputGenerator)
 	if err != nil {
 		panic(err)
 	}
@@ -73,14 +73,14 @@ func main() {
 	discriminatorTrain := defineDiscriminator(trainDiscriminatorGraph)
 	// Initialize Discriminator feedforward
 	inputDiscriminatorTrain := gorgonia.NewMatrix(trainDiscriminatorGraph, gorgonia.Float64, gorgonia.WithShape(2*batchSize, 2), gorgonia.WithName("discriminator_train_input"))
-	discriminatorTrain.Fwd(2*batchSize, inputDiscriminatorTrain)
+	discriminatorTrain.Fwd(inputDiscriminatorTrain)
 
 	// Define GAN on the same evaluation graph as Generator has been defined
 	definedGAN, err := gan.NewGAN(ganGraph, definedGenerator, discriminatorTrain)
 	if err != nil {
 		panic(err)
 	}
-	definedGAN.Fwd(batchSize)
+	definedGAN.Fwd()
 
 	/* Define variables for reading evaluation graphs' (both GAN and Discriminator in training mode) output */
 	// GAN Generator output

--- a/cmd/examples/sin/main.go
+++ b/cmd/examples/sin/main.go
@@ -64,7 +64,7 @@ func main() {
 	definedGenerator := defineGenerator(ganGraph)
 	// Initialize Generator feedforward
 	inputGenerator := gorgonia.NewMatrix(ganGraph, gorgonia.Float64, gorgonia.WithShape(batchSize, latentSpaceSize), gorgonia.WithName("generator_input"))
-	err = definedGenerator.Fwd(batchSize, inputGenerator)
+	err = definedGenerator.Fwd(inputGenerator)
 	if err != nil {
 		panic(err)
 	}
@@ -73,14 +73,14 @@ func main() {
 	discriminatorTrain := defineDiscriminator(trainDiscriminatorGraph)
 	// Initialize Discriminator feedforward
 	inputDiscriminatorTrain := gorgonia.NewMatrix(trainDiscriminatorGraph, gorgonia.Float64, gorgonia.WithShape(2*batchSize, 2), gorgonia.WithName("discriminator_train_input"))
-	discriminatorTrain.Fwd(2*batchSize, inputDiscriminatorTrain)
+	discriminatorTrain.Fwd(inputDiscriminatorTrain)
 
 	// Define GAN on the same evaluation graph as Generator has been defined
 	definedGAN, err := gan.NewGAN(ganGraph, definedGenerator, discriminatorTrain)
 	if err != nil {
 		panic(err)
 	}
-	definedGAN.Fwd(batchSize)
+	definedGAN.Fwd()
 
 	/* Define variables for reading evaluation graphs' (both GAN and Discriminator in training mode) output */
 	// GAN Generator output

--- a/cmd/examples/train_cnn/main.go
+++ b/cmd/examples/train_cnn/main.go
@@ -71,7 +71,7 @@ func main() {
 
 	/* Prepare tensor for input values */
 	inputCNN := gorgonia.NewTensor(cnnGraph, gorgonia.Float64, 4, gorgonia.WithShape(imgShape...), gorgonia.WithName("discriminator_train_input"))
-	err := simpleCNN.Fwd(batchSize, inputCNN)
+	err := simpleCNN.Fwd(inputCNN)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/examples/train_embedding/main.go
+++ b/cmd/examples/train_embedding/main.go
@@ -125,7 +125,7 @@ func main() {
 	inputShape := tensor.Shape{maxPadding}
 	batchSize := 1
 	inputNet := gorgonia.NewTensor(netGraph, gorgonia.Int, 1, gorgonia.WithShape(inputShape...), gorgonia.WithName("discriminator_train_input"))
-	err := simpleNet.Fwd(batchSize, inputNet)
+	err := simpleNet.Fwd(inputNet)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/examples/train_gru/main.go
+++ b/cmd/examples/train_gru/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	/* Prepare tensor for input values */
 	inputNet := gorgonia.NewTensor(netGraph, gorgonia.Int, 1, gorgonia.WithShape(sequenceLength), gorgonia.WithName("gru_train_input"))
-	err := gruNet.Fwd(1, inputNet)
+	err := gruNet.Fwd(inputNet)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/examples/train_lstm/main.go
+++ b/cmd/examples/train_lstm/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	/* Prepare tensor for input values */
 	inputNet := gorgonia.NewTensor(netGraph, gorgonia.Int, 1, gorgonia.WithShape(sequenceLength), gorgonia.WithName("lstm_train_input"))
-	err := lstmNet.Fwd(1, inputNet)
+	err := lstmNet.Fwd(inputNet)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/examples/train_rnn/main.go
+++ b/cmd/examples/train_rnn/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	/* Prepare tensor for input values */
 	inputNet := gorgonia.NewTensor(netGraph, gorgonia.Int, 1, gorgonia.WithShape(sequenceLength), gorgonia.WithName("rnn_train_input"))
-	err := rnnNet.Fwd(1, inputNet)
+	err := rnnNet.Fwd(inputNet)
 	if err != nil {
 		panic(err)
 	}

--- a/discriminator.go
+++ b/discriminator.go
@@ -33,10 +33,9 @@ func (net *DiscriminatorNet) Learnables() gorgonia.Nodes {
 
 // Fwd Initializates feedforward for provided input
 //
-// input - Input node (or nodes)
-// batchSize - batch size. If it's >= 2 then broadcast function will be applied
-func (net *DiscriminatorNet) Fwd(batchSize int, inputs ...*gorgonia.Node) error {
-	if err := net.private.Fwd(batchSize, inputs...); err != nil {
+// input - Input node (or nodes). Batch size is derived from shapes of the inputs
+func (net *DiscriminatorNet) Fwd(inputs ...*gorgonia.Node) error {
+	if err := net.private.Fwd(inputs...); err != nil {
 		return errors.Wrap(err, "[Discriminator]")
 	}
 	return nil

--- a/gan.go
+++ b/gan.go
@@ -88,10 +88,10 @@ func (net *GAN) GeneratorLearnables() gorgonia.Nodes {
 
 // Fwd Initializates feedforward for provided input for disciminator part of GAN
 //
-// batchSize - batch size. If it's >= 2 then broadcast function will be applied
-// Note: input node is not needed since input for Discriminator is just Generator's output
-func (net *GAN) Fwd(batchSize int) error {
-	if err := net.modifiedDiscriminator.Fwd(batchSize, net.generatorPart.Out()); err != nil {
+// Note: input node is not needed since input for Discriminator is just Generator's output.
+// Batch size is derived from shape of Generator's output
+func (net *GAN) Fwd() error {
+	if err := net.modifiedDiscriminator.Fwd(net.generatorPart.Out()); err != nil {
 		return errors.Wrap(err, "[GAN, Discriminator part]")
 	}
 	net.out = net.modifiedDiscriminator.private.out

--- a/gan_test.go
+++ b/gan_test.go
@@ -70,7 +70,7 @@ func TestNewGANSharedWeights(t *testing.T) {
 		},
 	)
 	genInput := mk11(ganGraph, "gen_in", 1.0)
-	if err := generator.Fwd(1, genInput); err != nil {
+	if err := generator.Fwd(genInput); err != nil {
 		t.Fatal(err)
 	}
 
@@ -86,7 +86,7 @@ func TestNewGANSharedWeights(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := theGAN.Fwd(1); err != nil {
+	if err := theGAN.Fwd(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/generator.go
+++ b/generator.go
@@ -33,10 +33,9 @@ func (net *GeneratorNet) Learnables() gorgonia.Nodes {
 
 // Fwd Initializates feedforward for provided input
 //
-// input - Input node (or nodes)
-// batchSize - batch size. If it's >= 2 then broadcast function will be applied
-func (net *GeneratorNet) Fwd(batchSize int, inputs ...*gorgonia.Node) error {
-	if err := net.private.Fwd(batchSize, inputs...); err != nil {
+// input - Input node (or nodes). Batch size is derived from shapes of the inputs
+func (net *GeneratorNet) Fwd(inputs ...*gorgonia.Node) error {
+	if err := net.private.Fwd(inputs...); err != nil {
 		return errors.Wrap(err, "[Generator]")
 	}
 	return nil

--- a/layer.go
+++ b/layer.go
@@ -10,7 +10,10 @@ import (
 
 // Layer Interface for a single layer of a neural network.
 //
-// Fwd - Builds forward pass for provided inputs and returns non-activated output node
+// Fwd - Builds forward pass for provided inputs and returns non-activated output node.
+//
+//	Batch size is derived from shapes of the inputs, first dimension is considered to be the batch one.
+//
 // Activate - Applies layer's activation function to non-activated output node.
 //
 //	Layers which do not imply activation (e.g. Flatten/Reshape/Dropout/Embedding) just return input node as is.
@@ -21,7 +24,7 @@ import (
 //	Learnable nodes of the copy are new nodes bound to THE SAME underlying tensors,
 //	see notes for NewGAN in gan.go about this shared-memory trick.
 type Layer interface {
-	Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error)
+	Fwd(inputs ...*gorgonia.Node) (*gorgonia.Node, error)
 	Activate(input *gorgonia.Node) (*gorgonia.Node, error)
 	Learnables() gorgonia.Nodes
 	CloneTo(g *gorgonia.ExprGraph, nameSuffix string) (Layer, error)
@@ -40,12 +43,12 @@ func singleInput(layerType string, inputs ...*gorgonia.Node) (*gorgonia.Node, er
 
 // addBias Helper adding bias node to non-activated output of a layer.
 // If bias node is nil then non-activated output is returned as is.
-//
-// batchSize - batch size. If it's >= 2 then broadcast function will be applied
-func addBias(layerNonActivated, bias *gorgonia.Node, batchSize int) (*gorgonia.Node, error) {
+// If batch size (first dimension of the non-activated output) is >= 2 then broadcast function will be applied
+func addBias(layerNonActivated, bias *gorgonia.Node) (*gorgonia.Node, error) {
 	if bias == nil {
 		return layerNonActivated, nil
 	}
+	batchSize := layerNonActivated.Shape()[0]
 	if batchSize < 2 {
 		withBias, err := gorgonia.Add(layerNonActivated, bias)
 		if err != nil {

--- a/layer_avgpool.go
+++ b/layer_avgpool.go
@@ -17,7 +17,7 @@ type AvgpoolLayer struct {
 }
 
 // Fwd Initializates feedforward for provided input
-func (layer *AvgpoolLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
+func (layer *AvgpoolLayer) Fwd(inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
 	input, err := singleInput("avgpool", inputs...)
 	if err != nil {
 		return nil, err

--- a/layer_avgpool_test.go
+++ b/layer_avgpool_test.go
@@ -27,7 +27,7 @@ func TestAvgpoolForward(t *testing.T) {
 		Padding:      []int{0, 0},
 		Stride:       []int{2, 2},
 	}
-	out, err := layer.Fwd(1, in)
+	out, err := layer.Fwd(in)
 	if err != nil {
 		t.Fatalf("Fwd error: %v", err)
 	}

--- a/layer_conv2d.go
+++ b/layer_conv2d.go
@@ -22,9 +22,7 @@ type Conv2DLayer struct {
 }
 
 // Fwd Initializates feedforward for provided input
-//
-// batchSize - batch size. If it's >= 2 then broadcast function will be applied for bias part
-func (layer *Conv2DLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
+func (layer *Conv2DLayer) Fwd(inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
 	input, err := singleInput("conv2d", inputs...)
 	if err != nil {
 		return nil, err
@@ -36,7 +34,7 @@ func (layer *Conv2DLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgoni
 	if err != nil {
 		return nil, errors.Wrap(err, "Can't convolve[2D] input by kernel of layer")
 	}
-	return addBias(layerNonActivated, layer.BiasNode, batchSize)
+	return addBias(layerNonActivated, layer.BiasNode)
 }
 
 // Activate Applies layer's activation function

--- a/layer_dropout.go
+++ b/layer_dropout.go
@@ -14,7 +14,7 @@ type DropoutLayer struct {
 }
 
 // Fwd Initializates feedforward for provided input
-func (layer *DropoutLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
+func (layer *DropoutLayer) Fwd(inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
 	input, err := singleInput("dropout", inputs...)
 	if err != nil {
 		return nil, err

--- a/layer_embedding.go
+++ b/layer_embedding.go
@@ -16,7 +16,7 @@ type EmbeddingLayer struct {
 }
 
 // Fwd Initializates feedforward for provided input
-func (layer *EmbeddingLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
+func (layer *EmbeddingLayer) Fwd(inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
 	input, err := singleInput("embedding", inputs...)
 	if err != nil {
 		return nil, err

--- a/layer_flatten.go
+++ b/layer_flatten.go
@@ -6,17 +6,19 @@ import (
 	"gorgonia.org/tensor"
 )
 
-// FlattenLayer Represents input tensor as [batchSize x Total number of elements in tensor / batchSize].
+// FlattenLayer Represents input tensor as [batch x Total number of elements in tensor / batch].
+// Batch size is derived from the first dimension of the input.
 // Has no learnable parameters and no activation.
 type FlattenLayer struct {
 }
 
 // Fwd Initializates feedforward for provided input
-func (layer *FlattenLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
+func (layer *FlattenLayer) Fwd(inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
 	input, err := singleInput("flatten", inputs...)
 	if err != nil {
 		return nil, err
 	}
+	batchSize := input.Shape()[0]
 	flatten, err := gorgonia.Reshape(input, tensor.Shape{batchSize, input.Shape().TotalSize() / batchSize})
 	if err != nil {
 		return nil, errors.Wrap(err, "Can't flatten input of layer")

--- a/layer_gradients_test.go
+++ b/layer_gradients_test.go
@@ -66,7 +66,7 @@ func numericGradCheck(t *testing.T, g *gorgonia.ExprGraph, out *gorgonia.Node, l
 
 func TestLSTMGradients(t *testing.T) {
 	g, layer, xNode, _ := buildLSTMFixture(t)
-	out, err := layer.Fwd(1, xNode)
+	out, err := layer.Fwd(xNode)
 	if err != nil {
 		t.Fatalf("Fwd error: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestLSTMGradients(t *testing.T) {
 
 func TestGRUGradients(t *testing.T) {
 	g, layer, xNode, _ := buildGRUFixture(t)
-	out, err := layer.Fwd(1, xNode)
+	out, err := layer.Fwd(xNode)
 	if err != nil {
 		t.Fatalf("Fwd error: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestGRUGradients(t *testing.T) {
 
 func TestRNNGradients(t *testing.T) {
 	g, layer, xNode, _ := buildRNNFixture(t)
-	out, err := layer.Fwd(1, xNode)
+	out, err := layer.Fwd(xNode)
 	if err != nil {
 		t.Fatalf("Fwd error: %v", err)
 	}

--- a/layer_gru.go
+++ b/layer_gru.go
@@ -56,8 +56,7 @@ func (layer *GRULayer) FinalHidden() *gorgonia.Node {
 // Fwd Initializates feedforward for provided input
 //
 // inputs - either single input node or (input, initial hidden state) pair
-// batchSize - not used by this layer type since batch size is derived from the input shape
-func (layer *GRULayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
+func (layer *GRULayer) Fwd(inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
 	var input, hiddenState *gorgonia.Node
 	switch len(inputs) {
 	case 1:
@@ -134,7 +133,7 @@ func (layer *GRULayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.N
 		if err != nil {
 			return nil, errors.Wrap(err, "Can't multiply time step input and input weights of GRU layer")
 		}
-		inputProjection, err = addBias(inputProjection, layer.BiasNode, batch)
+		inputProjection, err = addBias(inputProjection, layer.BiasNode)
 		if err != nil {
 			return nil, errors.Wrap(err, "Can't add bias to input projection of GRU layer")
 		}

--- a/layer_gru_test.go
+++ b/layer_gru_test.go
@@ -107,7 +107,7 @@ func buildGRUFixture(t *testing.T) (*gorgonia.ExprGraph, *GRULayer, *gorgonia.No
 
 func TestGRUForward(t *testing.T) {
 	g, layer, xNode, want := buildGRUFixture(t)
-	out, err := layer.Fwd(1, xNode)
+	out, err := layer.Fwd(xNode)
 	if err != nil {
 		t.Fatalf("Fwd error: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestGRUForward(t *testing.T) {
 
 func TestGRUSolverStep(t *testing.T) {
 	g, layer, xNode, _ := buildGRUFixture(t)
-	out, err := layer.Fwd(1, xNode)
+	out, err := layer.Fwd(xNode)
 	if err != nil {
 		t.Fatalf("Fwd error: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestGRUHiddenSizeOne(t *testing.T) {
 		BiasNode:         bNode,
 		HiddenSize:       H,
 	}
-	out, err := layer.Fwd(1, xNode)
+	out, err := layer.Fwd(xNode)
 	if err != nil {
 		t.Fatalf("Fwd error: %v", err)
 	}

--- a/layer_linear.go
+++ b/layer_linear.go
@@ -14,10 +14,10 @@ type LinearLayer struct {
 	Activation ActivationFunc
 }
 
-// Fwd Initializates feedforward for provided input
-//
-// batchSize - batch size. If it's >= 2 then batched multiplication/broadcasting will be applied
-func (layer *LinearLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
+// Fwd Initializates feedforward for provided input.
+// Plain matrix multiplication handles 2D input of any batch size,
+// batched multiplication is applied for inputs of higher dimensions
+func (layer *LinearLayer) Fwd(inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
 	input, err := singleInput("linear", inputs...)
 	if err != nil {
 		return nil, err
@@ -30,18 +30,18 @@ func (layer *LinearLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgoni
 		return nil, errors.Wrap(err, "Can't transpose weights of layer")
 	}
 	var layerNonActivated *gorgonia.Node
-	if batchSize < 2 {
+	if input.Dims() <= 2 {
 		layerNonActivated, err = gorgonia.Mul(input, tOp)
 		if err != nil {
-			return nil, errors.Wrap(err, "Can't multiply input and weights of layer [batch_size = 1]")
+			return nil, errors.Wrap(err, "Can't multiply input and weights of layer")
 		}
 	} else {
 		layerNonActivated, err = gorgonia.BatchedMatMul(input, tOp)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("Can't multiply input and weights of layer [batch_size = %d]", batchSize))
+			return nil, errors.Wrap(err, "Can't multiply input and weights of layer [batched]")
 		}
 	}
-	return addBias(layerNonActivated, layer.BiasNode, batchSize)
+	return addBias(layerNonActivated, layer.BiasNode)
 }
 
 // Activate Applies layer's activation function

--- a/layer_lstm.go
+++ b/layer_lstm.go
@@ -61,8 +61,7 @@ func (layer *LSTMLayer) FinalCell() *gorgonia.Node {
 // Fwd Initializates feedforward for provided input
 //
 // inputs - either single input node or (input, initial hidden state, initial cell state) triple
-// batchSize - not used by this layer type since batch size is derived from the input shape
-func (layer *LSTMLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
+func (layer *LSTMLayer) Fwd(inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
 	var input, hiddenState, cellState *gorgonia.Node
 	switch len(inputs) {
 	case 1:
@@ -145,7 +144,7 @@ func (layer *LSTMLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.
 		if err != nil {
 			return nil, errors.Wrap(err, "Can't sum input and hidden projections of LSTM layer")
 		}
-		gates, err = addBias(gates, layer.BiasNode, batch)
+		gates, err = addBias(gates, layer.BiasNode)
 		if err != nil {
 			return nil, errors.Wrap(err, "Can't add bias to gates of LSTM layer")
 		}

--- a/layer_lstm_test.go
+++ b/layer_lstm_test.go
@@ -102,7 +102,7 @@ func buildLSTMFixture(t *testing.T) (*gorgonia.ExprGraph, *LSTMLayer, *gorgonia.
 
 func TestLSTMForward(t *testing.T) {
 	g, layer, xNode, want := buildLSTMFixture(t)
-	out, err := layer.Fwd(1, xNode)
+	out, err := layer.Fwd(xNode)
 	if err != nil {
 		t.Fatalf("Fwd error: %v", err)
 	}
@@ -131,7 +131,7 @@ func TestLSTMForward(t *testing.T) {
 
 func TestLSTMSolverStep(t *testing.T) {
 	g, layer, xNode, _ := buildLSTMFixture(t)
-	out, err := layer.Fwd(1, xNode)
+	out, err := layer.Fwd(xNode)
 	if err != nil {
 		t.Fatalf("Fwd error: %v", err)
 	}
@@ -185,7 +185,7 @@ func TestLSTMHiddenSizeOne(t *testing.T) {
 		BiasNode:         bNode,
 		HiddenSize:       H,
 	}
-	out, err := layer.Fwd(1, xNode)
+	out, err := layer.Fwd(xNode)
 	if err != nil {
 		t.Fatalf("Fwd error: %v", err)
 	}

--- a/layer_maxpool.go
+++ b/layer_maxpool.go
@@ -17,7 +17,7 @@ type MaxpoolLayer struct {
 }
 
 // Fwd Initializates feedforward for provided input
-func (layer *MaxpoolLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
+func (layer *MaxpoolLayer) Fwd(inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
 	input, err := singleInput("maxpool", inputs...)
 	if err != nil {
 		return nil, err

--- a/layer_reshape.go
+++ b/layer_reshape.go
@@ -12,7 +12,7 @@ type ReshapeLayer struct {
 }
 
 // Fwd Initializates feedforward for provided input
-func (layer *ReshapeLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
+func (layer *ReshapeLayer) Fwd(inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
 	input, err := singleInput("reshape", inputs...)
 	if err != nil {
 		return nil, err

--- a/layer_rnn.go
+++ b/layer_rnn.go
@@ -50,8 +50,7 @@ func (layer *RNNLayer) FinalHidden() *gorgonia.Node {
 // Fwd Initializates feedforward for provided input
 //
 // inputs - either single input node or (input, initial hidden state) pair
-// batchSize - not used by this layer type since batch size is derived from the input shape
-func (layer *RNNLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
+func (layer *RNNLayer) Fwd(inputs ...*gorgonia.Node) (*gorgonia.Node, error) {
 	var input, hiddenState *gorgonia.Node
 	switch len(inputs) {
 	case 1:
@@ -125,7 +124,7 @@ func (layer *RNNLayer) Fwd(batchSize int, inputs ...*gorgonia.Node) (*gorgonia.N
 		if err != nil {
 			return nil, errors.Wrap(err, "Can't sum input and hidden projections of RNN layer")
 		}
-		preActivation, err = addBias(preActivation, layer.BiasNode, batch)
+		preActivation, err = addBias(preActivation, layer.BiasNode)
 		if err != nil {
 			return nil, errors.Wrap(err, "Can't add bias to pre-activation of RNN layer")
 		}

--- a/layer_rnn_test.go
+++ b/layer_rnn_test.go
@@ -86,7 +86,7 @@ func buildRNNFixture(t *testing.T) (*gorgonia.ExprGraph, *RNNLayer, *gorgonia.No
 
 func TestRNNForward(t *testing.T) {
 	g, layer, xNode, want := buildRNNFixture(t)
-	out, err := layer.Fwd(1, xNode)
+	out, err := layer.Fwd(xNode)
 	if err != nil {
 		t.Fatalf("Fwd error: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestRNNForward(t *testing.T) {
 
 func TestRNNSolverStep(t *testing.T) {
 	g, layer, xNode, _ := buildRNNFixture(t)
-	out, err := layer.Fwd(1, xNode)
+	out, err := layer.Fwd(xNode)
 	if err != nil {
 		t.Fatalf("Fwd error: %v", err)
 	}

--- a/layer_validation_test.go
+++ b/layer_validation_test.go
@@ -13,7 +13,7 @@ func TestDropoutProbabilityValidation(t *testing.T) {
 		layer := &DropoutLayer{
 			Probability: probability,
 		}
-		if _, err := layer.Fwd(1, in); err == nil {
+		if _, err := layer.Fwd(in); err == nil {
 			t.Errorf("dropout probability %v accepted, expected error", probability)
 		}
 	}
@@ -25,7 +25,7 @@ func TestLinearNilWeights(t *testing.T) {
 	layer := &LinearLayer{
 		Activation: NoActivation,
 	}
-	if _, err := layer.Fwd(1, in); err == nil {
+	if _, err := layer.Fwd(in); err == nil {
 		t.Error("linear layer with nil weights accepted, expected error")
 	}
 }
@@ -34,10 +34,10 @@ func TestSingleInputValidation(t *testing.T) {
 	g := gorgonia.NewGraph()
 	in := gorgonia.NewMatrix(g, gorgonia.Float64, gorgonia.WithShape(1, 2), gorgonia.WithName("flin"), gorgonia.WithInit(gorgonia.Ones()))
 	layer := &FlattenLayer{}
-	if _, err := layer.Fwd(1); err == nil {
+	if _, err := layer.Fwd(); err == nil {
 		t.Error("no inputs accepted, expected error")
 	}
-	if _, err := layer.Fwd(1, in, in); err == nil {
+	if _, err := layer.Fwd(in, in); err == nil {
 		t.Error("two inputs accepted, expected error")
 	}
 }

--- a/network.go
+++ b/network.go
@@ -35,9 +35,9 @@ func (net *Network) Learnables() gorgonia.Nodes {
 
 // Fwd Initializates feedforward for provided input
 //
-// inputs - Input node (or nodes). Only first layer of network can accept multiple inputs
-// batchSize - batch size. If it's >= 2 then broadcast function will be applied
-func (net *Network) Fwd(batchSize int, inputs ...*gorgonia.Node) error {
+// inputs - Input node (or nodes). Only first layer of network can accept multiple inputs.
+// Batch size is derived from shapes of the inputs
+func (net *Network) Fwd(inputs ...*gorgonia.Node) error {
 	if len(inputs) == 0 {
 		return fmt.Errorf("There are no input nodes for network")
 	}
@@ -57,7 +57,7 @@ func (net *Network) Fwd(batchSize int, inputs ...*gorgonia.Node) error {
 		if layer == nil {
 			return fmt.Errorf("Network's layer #%d is nil", i)
 		}
-		layerNonActivated, err := layer.Fwd(batchSize, layerInputs...)
+		layerNonActivated, err := layer.Fwd(layerInputs...)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("[Network, Layer #%d] Can't feedforward input before activation", i))
 		}


### PR DESCRIPTION
- `batchSize` argument is removed from `Layer.Fwd`, `Network.Fwd`, `Generator.Fwd`, `Discriminator.Fwd` and `GAN.Fwd`: batch size is derived from shapes of the inputs (first dimension is considered to be the batch one). The explicit argument was redundant and error prone, e.g. the discriminator of a GAN required manual doubling (`Fwd(2*batchSize, ...)`) for real+fake batches.
- `LinearLayer` uses plain matrix multiplication for 2D inputs of any batch size, batched multiplication is kept for inputs of higher dimensions. Bias broadcasting and `FlattenLayer` derive batch from the input shape as well.

**Breaking change**, migration is a pure deletion of the first argument:

```go
// before
generator.Fwd(batchSize, input)
discriminator.Fwd(2*batchSize, input)
gan.Fwd(batchSize)
// after
generator.Fwd(input)
discriminator.Fwd(input)
gan.Fwd()
```